### PR TITLE
feat: Add support for file extension filtering and specific file exclusion in processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ Add the task to your Azure Pipelines YAML:
     maxTokens: '1000'
     temperature: '0.7'
     active: true
+    allowedFileExtensions: '.cs, .sql, .ts, .js, .html' 
+    exclusionString: 'ai-pr-ignore' 
 ```
 
 > **💡 Pro Tip**: Using `@1` (major version) automatically gets the latest compatible version. Avoid using specific versions like `@1.0.13` to get automatic updates. 
@@ -104,6 +106,8 @@ Add the task to your Azure Pipelines YAML:
 - **promptTemplate**: Template for the AI prompt (use {diff} to include PR changes and {standards} to include coding standards)
 - **maxTokens**: Maximum number of tokens for the AI response
 - **temperature**: Controls randomness in the AI response (0.0-1.0)
+- **allowedFileExtentions**: Only files with these extentions will be included in the pr review
+- **exclusionString**: Files with this string in their content will be excluded from the pr review
 
 #### Comment Options
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,30 @@ async function run() {
         
         // Create a comment for each file
         for (const [filePath, fileContent] of Object.entries(completeFiles)) {
+
+          // Get file extensions to process (if specified)
+          const fileExtensions = tl.getDelimitedInput('fileExtensions', ',', false) || [];
+          if (fileExtensions.length > 0) {
+            const fileExtension = path.extname(filePath).toLowerCase();
+            const shouldProcess = fileExtensions.some((ext: string) => {
+              const normalizedExt = ext.trim().toLowerCase();
+              return normalizedExt === fileExtension || normalizedExt === fileExtension.substring(1);
+            });
+            
+            if (!shouldProcess) {
+              console.log(`Skipping file ${filePath} - extension ${fileExtension} not in allowed list: ${fileExtensions.join(', ')}`);
+              continue;
+            }
+          }
+
+          const exclusionString = tl.getInput('exclusionString', false);
+          if (exclusionString) {
+            if (fileContent.includes(exclusionString)) {
+              console.log(`Skipping file ${filePath} - excluded by user`);
+              continue;
+            }
+          }
+
           // Create a file-specific prompt
           const filePrompt = promptTemplate
             .replace('{diff}', `File: ${filePath}\n\n${fileContent}`)

--- a/src/task.json
+++ b/src/task.json
@@ -182,6 +182,22 @@
         "label": "Pull Request Repository ID",
         "required": false,
         "helpMarkDown": "Add comment to pull request in this repository. If not specified, the comment will be added to the current repository."
+      },
+      {
+        "name": "allowedFileExtensions",
+        "type": "string",
+        "defaultValue": "",
+        "label": "Add file types to include in processing.",
+        "required": false,
+        "helpMarkDown": "Comma-separated list of file extensions to include in processing (e.g. .js,.ts,.jsx,.tsx)."
+      },
+      {
+        "name": "exclusionString",
+        "type": "string",
+        "defaultValue": "",
+        "label": "Add exclusionString to exclude file from processing.",
+        "required": false,
+        "helpMarkDown": "String to exclude files from processing. If file contains this string, it will be excluded from processing."
       }
     ],
     "execution": {


### PR DESCRIPTION
This pull request adds new filtering options to control which files are processed when creating comments for each file. The main changes introduce support for specifying allowed file extensions and an exclusion string, both configurable via new inputs in the task definition.

**File filtering enhancements:**

* Added support for filtering files by extension in `src/index.ts`, using the new `allowedFileExtensions` input to process only files with specified extensions.
* Implemented exclusion logic in `src/index.ts` to skip files containing a user-defined `exclusionString`.

**Task configuration updates:**

* Added `allowedFileExtensions` and `exclusionString` inputs to `src/task.json`, allowing users to configure file filtering directly in the task UI.