### PR TITLE
Fix allowedFileExtensions parameter not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed `allowedFileExtensions` parameter not working due to incorrect parameter name in code
+- The task.json defined `allowedFileExtensions` but the TypeScript code was reading `fileExtensions`
+- File extension filtering now works correctly as documented
+
 ## [1.0.14] - 2025-08-08
 
 ### Changed

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ async function run() {
         for (const [filePath, fileContent] of Object.entries(completeFiles)) {
 
           // Get file extensions to process (if specified)
-          const fileExtensions = tl.getDelimitedInput('fileExtensions', ',', false) || [];
+          const fileExtensions = tl.getDelimitedInput('allowedFileExtensions', ',', false) || [];
           if (fileExtensions.length > 0) {
             const fileExtension = path.extname(filePath).toLowerCase();
             const shouldProcess = fileExtensions.some((ext: string) => {


### PR DESCRIPTION
- Fixed incorrect parameter name in TypeScript code
- task.json defined 'allowedFileExtensions' but code was reading 'fileExtensions'
- File extension filtering now works correctly as documented
- Updated CHANGELOG.md with fix description

Fixes file extension filtering functionality that was completely broken due to parameter name mismatch.