### PR TITLE
Add marketplace deploy workflow and version-bump helper

### DIFF
--- a/.github/workflows/marketplace-deploy.yml
+++ b/.github/workflows/marketplace-deploy.yml
@@ -1,0 +1,41 @@
+name: Deploy to Marketplace
+
+# Publishes the extension to the Visual Studio Marketplace when a version tag is pushed.
+# Only users with write access can push tags, so only maintainers can trigger a deploy.
+# The `production` environment adds a required-reviewer gate (configure in repo Settings).
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Verify tag matches manifest version
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          MANIFEST="$(node -p "require('./vss-extension.json').version")"
+          echo "Tag version: $TAG | Manifest version: $MANIFEST"
+          if [ "$TAG" != "$MANIFEST" ]; then
+            echo "::error::Tag v$TAG does not match vss-extension.json version $MANIFEST. Bump the version files to match the tag."
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build
+        run: bun run build
+
+      - name: Publish to Marketplace
+        env:
+          AZDO_PAT: ${{ secrets.AZDO_PAT }}
+        run: npx tfx-cli@latest extension publish --publisher ByteInSights --token "$AZDO_PAT"

--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,8 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Claude Code
+.claude/
+CLAUDE.md
+CLAUDE.local.md

--- a/scripts/bump-version.js
+++ b/scripts/bump-version.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Bump the extension version across the three files that must stay in sync.
+// Usage: node scripts/bump-version.js <major|minor|patch|X.Y.Z>
+// Edits only the version fields in place — preserves each file's existing formatting.
+const fs = require('fs');
+
+const arg = process.argv[2] || 'patch';
+
+// Current version is the source of truth in vss-extension.json.
+const vssText = fs.readFileSync('vss-extension.json', 'utf8');
+const cur = (vssText.match(/"version"\s*:\s*"(\d+)\.(\d+)\.(\d+)"/) || []);
+if (!cur.length) {
+  console.error('Could not read current version from vss-extension.json');
+  process.exit(1);
+}
+const [maj, min, pat] = [Number(cur[1]), Number(cur[2]), Number(cur[3])];
+
+let next;
+if (/^\d+\.\d+\.\d+$/.test(arg)) next = arg;
+else if (arg === 'major') next = `${maj + 1}.0.0`;
+else if (arg === 'minor') next = `${maj}.${min + 1}.0`;
+else if (arg === 'patch') next = `${maj}.${min}.${pat + 1}`;
+else {
+  console.error(`Unknown bump arg "${arg}". Use major|minor|patch|X.Y.Z`);
+  process.exit(1);
+}
+const [nMaj, nMin, nPat] = next.split('.').map(Number);
+
+// package.json + vss-extension.json: replace the "version": "X.Y.Z" string field.
+for (const file of ['package.json', 'vss-extension.json']) {
+  const text = fs.readFileSync(file, 'utf8');
+  const updated = text.replace(/("version"\s*:\s*")\d+\.\d+\.\d+(")/, `$1${next}$2`);
+  if (updated === text) { console.error(`No version field updated in ${file}`); process.exit(1); }
+  fs.writeFileSync(file, updated);
+}
+
+// src/task.json: version is an object { Major, Minor, Patch }.
+let task = fs.readFileSync('src/task.json', 'utf8');
+const before = task;
+task = task
+  .replace(/("Major"\s*:\s*)\d+/, `$1${nMaj}`)
+  .replace(/("Minor"\s*:\s*)\d+/, `$1${nMin}`)
+  .replace(/("Patch"\s*:\s*)\d+/, `$1${nPat}`);
+if (task === before) { console.error('No version object updated in src/task.json'); process.exit(1); }
+fs.writeFileSync('src/task.json', task);
+
+console.log(`Bumped ${maj}.${min}.${pat} -> ${next} across package.json, vss-extension.json, src/task.json`);

--- a/scripts/copy-modules.js
+++ b/scripts/copy-modules.js
@@ -67,6 +67,35 @@ const packagesToCopy = allPackages
     return { name, mainJsFiles: [''] };
   }).flat();
 
+// Folders we never want to ship (tests, examples, coverage, docs, etc.)
+const EXCLUDED_FOLDER_NAMES = new Set([
+  'test', 'tests', 'spec', 'specs',
+  'example', 'examples', 'demo', 'demos',
+  'benchmark', 'benchmarks', '.nyc_output', 'coverage', 'docs',
+]);
+
+// Cross-platform recursive copy of files matching the given extensions,
+// preserving folder structure and skipping excluded folders. Pure Node so it
+// behaves identically on Windows, macOS, and Linux (no GNU/BSD cp differences).
+function copyFilesByExtension(sourceDir, destDir, extensions, { skipExcludedFolders = true } = {}) {
+  if (!fs.existsSync(sourceDir)) return;
+
+  const entries = fs.readdirSync(sourceDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = path.join(sourceDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (skipExcludedFolders && EXCLUDED_FOLDER_NAMES.has(entry.name)) continue;
+      copyFilesByExtension(srcPath, destPath, extensions, { skipExcludedFolders });
+    } else if (entry.isFile()) {
+      if (!extensions.some(ext => entry.name.endsWith(ext))) continue;
+      fs.mkdirSync(destDir, { recursive: true });
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
 // Function to remove problematic directories
 function removeProblematicDirs(dirPath) {
   // Skip if directory doesn't exist
@@ -156,26 +185,10 @@ try {
               fs.mkdirSync(destPath, { recursive: true });
             }
 
-            // Copy JS, CJS, and JSON files (recursively, preserving structure, excluding test folders)
-            if (process.platform === 'win32') {
-              console.log(`Copying JS, CJS, and JSON files from ${sourcePath} to ${destPath}`);
-              // xcopy cannot filter recursively by extension while preserving folder structure in one call reliably.
-              // Use PowerShell to mirror .js, .cjs, and .json files, excluding test/dev folders.
-              const ps = `Get-ChildItem -Path "${sourcePath}" -Recurse -Include *.js,*.cjs,*.json | Where-Object { $_.FullName -notmatch '\\\\(test|tests|spec|specs|example|examples|demo|demos|benchmark|benchmarks|\\.nyc_output|coverage|docs)\\\\' } | ForEach-Object { $rel = $_.FullName.Substring('${sourcePath}'.length).TrimStart('\\'); $target = Join-Path "${destPath}" $rel; New-Item -ItemType Directory -Path ([System.IO.Path]::GetDirectoryName($target)) -Force > $null; Copy-Item $_.FullName $target -Force }`;
-              execSync(`powershell -NoProfile -ExecutionPolicy Bypass -Command "${ps}"`);
-            } else {
-              console.log(`Copying JS, CJS, and JSON files from ${sourcePath} to ${destPath}`);
-              // For Unix-like systems - include .js, .cjs, and .json files, excluding test/dev folders
-              const escapedSourcePath = sourcePath.replace(/"/g, '\\"');
-              const escapedDestPath = destPath.replace(/"/g, '\\"');
-              const findCommand = `cd "${escapedSourcePath}" && find . \\( -name "*.js" -o -name "*.cjs" -o -name "*.json" \\) -type f ` +
-                `! -path "*/test/*" ! -path "*/tests/*" ! -path "*/spec/*" ! -path "*/specs/*" ` +
-                `! -path "*/example/*" ! -path "*/examples/*" ! -path "*/demo/*" ! -path "*/demos/*" ` +
-                `! -path "*/benchmark/*" ! -path "*/benchmarks/*" ! -path "*/.nyc_output/*" ` +
-                `! -path "*/coverage/*" ! -path "*/docs/*" ` +
-                `-exec cp --parents -t "${escapedDestPath}" {} \\;`;
-              execSync(findCommand);
-            }
+            // Copy JS, CJS, and JSON files (recursively, preserving structure, excluding test folders).
+            // Pure Node implementation works identically on Windows, macOS, and Linux.
+            console.log(`Copying JS, CJS, and JSON files from ${sourcePath} to ${destPath}`);
+            copyFilesByExtension(sourcePath, destPath, ['.js', '.cjs', '.json']);
           } else {
             console.log(`Source path ${sourcePath} doesn't exist, skipping`);
           }
@@ -203,13 +216,8 @@ try {
             fs.copyFileSync(nestedPkgJson, path.join(nestedUuidDest, 'package.json'));
           }
 
-          // Copy all JS files recursively
-          if (process.platform === 'win32') {
-            const psNested = `Get-ChildItem -Path "${nestedUuidSrc}" -Recurse -Filter *.js | ForEach-Object { $rel = $_.FullName.Substring('${nestedUuidSrc}'.length).TrimStart('\\'); $target = Join-Path "${nestedUuidDest}" $rel; New-Item -ItemType Directory -Path ([System.IO.Path]::GetDirectoryName($target)) -Force > $null; Copy-Item $_.FullName $target -Force }`;
-            execSync(`powershell -NoProfile -ExecutionPolicy Bypass -Command "${psNested}"`);
-          } else {
-            execSync(`find "${nestedUuidSrc}" -name "*.js" -type f -exec cp --parents -t "${nestedUuidDest}" {} \\;`);
-          }
+          // Copy all JS files recursively (cross-platform, pure Node)
+          copyFilesByExtension(nestedUuidSrc, nestedUuidDest, ['.js'], { skipExcludedFolders: false });
 
           // Create v4.js shim for legacy uuid structure
           const v4ShimPath = path.join(nestedUuidDest, 'v4.js');


### PR DESCRIPTION
## What this adds

Automation for publishing the extension to the Visual Studio Marketplace.

### `.github/workflows/marketplace-deploy.yml`
Triggers on pushing a `v*` tag. Steps:
1. Verifies the tag matches the version in `vss-extension.json` (fails the build on mismatch).
2. Builds with Bun (`bun install && bun run build`).
3. Publishes the extension. Runs in a gated environment requiring approval before publish; only maintainers can push tags.

### `scripts/bump-version.js`
Bumps the version in sync across the three files that must match (`package.json`, `vss-extension.json`, `src/task.json`). Edits version fields in place so each file keeps its own indentation, and exits non-zero if any file is left unchanged.

```bash
node scripts/bump-version.js patch   # or minor | major | X.Y.Z
```

## Release flow after merge
`node scripts/bump-version.js patch` → commit → merge PR → `git tag vX.Y.Z && git push --tags` → approve the gated deploy.