### PR TITLE
Add holistic AI PR review mode with test gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+# Runs the typecheck and test suite on every push and pull request so breakage
+# is caught early, before a release tag triggers the deploy workflow.
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - 'v*'          # version tags are covered by the deploy workflow's test gate
+  pull_request:
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/marketplace-deploy.yml
+++ b/.github/workflows/marketplace-deploy.yml
@@ -9,7 +9,26 @@ on:
       - 'v*'
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Run tests
+        run: bun test
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
     environment: production
     steps:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Add the task to your Azure Pipelines YAML:
 
 - **useAIGeneration**: Enable AI-generated comments
 - **aiProvider**: Select the AI provider (openai, azure, google, vertexai, anthropic, ollama)
-- **modelName**: Specify the model name (e.g., gpt-4, claude-3-opus, gemini-pro)
+- **modelName**: Specify the model name (e.g., gpt-5.4, claude-sonnet-4-6, gemini-3-pro, qwen3). Leave empty for the provider's current default.
 - **apiKey**: API key for the selected provider (use pipeline variables for security)
 - **azureApiEndpoint**: Custom API endpoint URL for Azure OpenAI
 - **ollamaApiEndpoint**: API endpoint URL for Ollama (default: http://localhost:11434)
@@ -117,6 +117,20 @@ Add the task to your Azure Pipelines YAML:
 - **analyzeChangesOnly**: When `true`, only the changed lines are analyzed; when `false`, the full file content is sent
 - **allowedFileExtentions**: Only files with these extentions will be included in the pr review
 - **exclusionString**: Files with this string in their content will be excluded from the pr review
+
+#### Holistic Review Options
+
+When AI generation is enabled, the task defaults to a **holistic review**: the AI sees the entire pull request at once (all changed files plus the PR title/description, linked work items, existing human comments, and your coding standards), then posts a single summary thread plus line-anchored findings, each with a severity. Re-runs are deduplicated by a content fingerprint, so the same finding is not re-posted on every push and findings that no longer apply are closed.
+
+- **reviewMode**: `holistic` (default — whole-PR review with a summary + line-anchored findings) or `perFile` (the legacy behaviour that comments on each file independently). Existing pipelines that relied on the per-file behaviour can set `reviewMode: perFile`.
+- **minSeverity**: Findings below this severity (`info`, `low`, `medium`, `high`, `critical`) are not posted; the count of suppressed findings is noted in the summary. Default `low`.
+- **customInstructions**: Optional free-text guidance injected into the review prompt (e.g. "Focus on security; this is a React 18 codebase"). Do **not** use it to dictate output format.
+- **enableVerification**: When `true` (default), candidate findings are sent back to the model for a confirm-or-drop pass to suppress false positives (roughly doubles token cost).
+- **maxInputTokens**: Approximate input budget (chars/4) for a single review call. Pull requests larger than this are split into batches that are reviewed separately and then synthesised. Default `200000`.
+- **skipDraftPullRequests**: When `true`, the holistic review is skipped for draft PRs.
+- **debug**: When `true`, assembled prompts are written to the agent temp directory for troubleshooting.
+
+> In holistic mode the **promptTemplate** is only used if you customise it away from the default; the legacy `{diff}` placeholders are not substituted (the task assembles its own file context), and the structured JSON output contract is always enforced. If a malfunction occurs (API error, unparseable output), the task warns and reports `SucceededWithIssues` rather than failing the build — findings never gate the pipeline.
 
 #### Comment Options
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Azure DevOps Extension for AI Generated PR Comments",
   "main": "dist/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "bun test",
     "clean": "node scripts/clean.js",
     "build": "npm run clean && npx tsc && npm run copy-task-json && npm run copy-node-modules",
     "copy-node-modules": "node scripts/copy-modules.js",

--- a/scripts/copy-modules.js
+++ b/scripts/copy-modules.js
@@ -30,6 +30,12 @@ const buildTimeOnlyPackages = [
   'style-loader',     // build tool
   'ts-loader',        // build tool
   'mini-css-extract-plugin', // build tool (if present)
+  'typescript',       // build tool (tsc) - never required at task runtime
+  // react/react-dom/scheduler are declared deps but unused by the Node task
+  // runtime (this is a pipeline task, not a web bundle). No imports in src/.
+  'react',
+  'react-dom',
+  'scheduler',
 ];
 
 // Get ALL packages from node_modules

--- a/src/ai-services.ts
+++ b/src/ai-services.ts
@@ -6,9 +6,24 @@ export interface AIResponse {
   error?: string;
 }
 
+// Optional per-call generation options. Kept optional so existing callers
+// (the legacy per-file path) keep working unchanged.
+export interface AIGenerateOptions {
+  // When true, ask the provider to return strict JSON. Providers whose SDK
+  // exposes a native JSON mode (OpenAI response_format) use it; the rest rely
+  // on prompt instructions, so the orchestrator must also instruct JSON in the
+  // prompt regardless.
+  jsonMode?: boolean;
+}
+
 // Base AI service interface
 export interface AIService {
-  generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse>;
+  generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse>;
 }
 
 // Helper function to determine if a model requires max_completion_tokens instead of max_tokens
@@ -48,12 +63,38 @@ function requiresMaxCompletionTokens(modelName: string): boolean {
   return false;
 }
 
+// Newer OpenAI models (GPT-5+, o-series) only accept the default temperature.
+// They are exactly the models that also require max_completion_tokens, so reuse
+// that detection rather than maintaining a second list.
+function openAiRejectsTemperature(modelName: string): boolean {
+  return requiresMaxCompletionTokens(modelName);
+}
+
+// Anthropic removed sampling parameters (temperature/top_p/top_k) on Opus 4.7,
+// Opus 4.8 and the Fable family — sending temperature returns a 400. Sonnet 4.6
+// and earlier still accept it. Detect the families that reject it.
+function anthropicRejectsTemperature(modelName: string): boolean {
+  const m = modelName.trim().toLowerCase();
+  if (m.includes('fable') || m.includes('mythos')) {
+    return true;
+  }
+  // claude-opus-4-7 / 4-8 (and any later opus 4.x ≥ 7) reject sampling params.
+  const opusMatch = m.match(/opus-4-(\d+)/);
+  if (opusMatch) {
+    const minor = parseInt(opusMatch[1], 10);
+    if (!Number.isNaN(minor) && minor >= 7) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // OpenAI implementation
 export class OpenAIService implements AIService {
   private client: any;
   private model: string;
 
-  constructor(apiKey: string, model: string = 'gpt-4o') {
+  constructor(apiKey: string, model: string = 'gpt-5.4') {
     // Lazy-load to avoid requiring 'openai' unless provider is used
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { OpenAI } = require('openai');
@@ -61,22 +102,37 @@ export class OpenAIService implements AIService {
     this.model = model;
   }
 
-  async generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse> {
+  async generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse> {
     try {
       // Build request body with appropriate parameter based on model
       const requestBody: any = {
         model: this.model,
         messages: [{ role: 'user', content: prompt }],
-        temperature: temperature,
       };
-      
-      // Use the appropriate parameter based on model version
+
+      // Newer reasoning models (GPT-5+, o-series) only accept the default
+      // temperature; sending a custom one 400s. Omit it for those.
+      if (!openAiRejectsTemperature(this.model)) {
+        requestBody.temperature = temperature;
+      }
+
+      // Use the appropriate token parameter based on model version
       if (requiresMaxCompletionTokens(this.model)) {
         requestBody.max_completion_tokens = maxTokens;
       } else {
         requestBody.max_tokens = maxTokens;
       }
-      
+
+      // Native JSON mode keeps the structured-output contract tight.
+      if (options?.jsonMode) {
+        requestBody.response_format = { type: 'json_object' };
+      }
+
       const response = await this.client.chat.completions.create(requestBody);
 
       return {
@@ -103,24 +159,37 @@ export class AzureOpenAIService implements AIService {
     this.deploymentName = deploymentName;
   }
 
-  async generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse> {
+  async generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse> {
     try {
       // Using the new Azure OpenAI API format
       const url = `${this.endpoint}/openai/deployments/${this.deploymentName}/chat/completions?api-version=2023-12-01-preview`;
-      
+
       const requestBody: any = {
         model: this.deploymentName,
         messages: [{ role: 'user', content: prompt }],
-        temperature: temperature,
       };
-      
+
+      // Newer reasoning deployments only accept the default temperature.
+      if (!openAiRejectsTemperature(this.deploymentName)) {
+        requestBody.temperature = temperature;
+      }
+
       // Use the appropriate parameter based on model version
       if (requiresMaxCompletionTokens(this.deploymentName)) {
         requestBody.max_completion_tokens = maxTokens;
       } else {
         requestBody.max_tokens = maxTokens;
       }
-      
+
+      if (options?.jsonMode) {
+        requestBody.response_format = { type: 'json_object' };
+      }
+
       const response = await axios.post(
         url,
         requestBody,
@@ -151,16 +220,29 @@ export class GoogleAIService implements AIService {
   private apiKey: string;
   private model: string;
 
-  constructor(apiKey: string, model: string = 'gemini-1.5-pro') {
+  constructor(apiKey: string, model: string = 'gemini-3-pro') {
     this.apiKey = apiKey;
     this.model = model;
   }
 
-  async generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse> {
+  async generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse> {
     try {
       // Using direct API call with axios instead of the DiscussServiceClient
       const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.model}:generateContent?key=${this.apiKey}`;
-      
+
+      const generationConfig: any = {
+        temperature: temperature,
+        maxOutputTokens: maxTokens
+      };
+      if (options?.jsonMode) {
+        generationConfig.responseMimeType = 'application/json';
+      }
+
       const response = await axios.post(
         url,
         {
@@ -169,10 +251,7 @@ export class GoogleAIService implements AIService {
               parts: [{ text: prompt }]
             }
           ],
-          generationConfig: {
-            temperature: temperature,
-            maxOutputTokens: maxTokens
-          }
+          generationConfig
         },
         {
           headers: {
@@ -202,13 +281,18 @@ export class VertexAIService implements AIService {
   private model: string;
   private vertexCtor?: any;
 
-  constructor(projectId: string, location: string = 'us-central1', model: string = 'gemini-1.5-pro') {
+  constructor(projectId: string, location: string = 'us-central1', model: string = 'gemini-3-pro') {
     this.projectId = projectId;
     this.location = location;
     this.model = model;
   }
 
-  async generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse> {
+  async generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse> {
     try {
       // Lazy-load to avoid requiring '@google-cloud/vertexai' unless provider is used
       if (!this.vertexCtor) {
@@ -221,12 +305,17 @@ export class VertexAIService implements AIService {
         location: this.location,
       });
 
+      const generationConfig: any = {
+        maxOutputTokens: maxTokens,
+        temperature: temperature,
+      };
+      if (options?.jsonMode) {
+        generationConfig.responseMimeType = 'application/json';
+      }
+
       const generativeModel = vertexAI.preview.getGenerativeModel({
         model: this.model,
-        generationConfig: {
-          maxOutputTokens: maxTokens,
-          temperature: temperature,
-        },
+        generationConfig,
       });
 
       const result = await generativeModel.generateContent({
@@ -250,7 +339,7 @@ export class AnthropicService implements AIService {
   private client: any;
   private model: string;
 
-  constructor(apiKey: string, model: string = 'claude-3.5-sonnet-20241022') {
+  constructor(apiKey: string, model: string = 'claude-sonnet-4-6') {
     // Lazy-load to avoid requiring '@anthropic-ai/sdk' unless provider is used
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { Anthropic } = require('@anthropic-ai/sdk');
@@ -258,20 +347,35 @@ export class AnthropicService implements AIService {
     this.model = model;
   }
 
-  async generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse> {
+  async generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    _options?: AIGenerateOptions
+  ): Promise<AIResponse> {
     try {
-      // Using the Anthropic SDK as shown in the example
-      const response = await this.client.messages.create({
+      // Using the Anthropic SDK as shown in the example. Note: structured JSON
+      // is driven by the prompt, not output_config.format — the bundled SDK
+      // predates that parameter, and prompt-based JSON is our cross-provider
+      // baseline anyway.
+      const requestBody: any = {
         model: this.model,
         max_tokens: maxTokens,
-        temperature: temperature,
         messages: [
           {
             role: 'user',
             content: prompt
           }
         ]
-      });
+      };
+
+      // Opus 4.7/4.8 and the Fable family reject sampling params (400). Only
+      // send temperature to models that still accept it.
+      if (!anthropicRejectsTemperature(this.model)) {
+        requestBody.temperature = temperature;
+      }
+
+      const response = await this.client.messages.create(requestBody);
 
       // Extract the text content safely
       let content = 'No response generated';
@@ -303,18 +407,30 @@ export class OllamaService implements AIService {
     this.model = model;
   }
 
-  async generateComment(prompt: string, maxTokens: number, temperature: number): Promise<AIResponse> {
+  async generateComment(
+    prompt: string,
+    maxTokens: number,
+    temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse> {
     try {
+      const requestBody: any = {
+        model: this.model,
+        prompt: prompt,
+        stream: false,
+        options: {
+          num_predict: maxTokens,
+          temperature: temperature,
+        },
+      };
+      // Ollama supports constrained JSON output via the top-level `format` field.
+      if (options?.jsonMode) {
+        requestBody.format = 'json';
+      }
+
       const response = await axios.post(
         `${this.endpoint}/api/generate`,
-        {
-          model: this.model,
-          prompt: prompt,
-          options: {
-            num_predict: maxTokens,
-            temperature: temperature,
-          },
-        }
+        requestBody
       );
 
       return {
@@ -343,23 +459,23 @@ export function createAIService(
   
   switch (provider) {
     case 'openai':
-      return new OpenAIService(apiKey, modelName || 'gpt-4o');
+      return new OpenAIService(apiKey, modelName || 'gpt-5.4');
     case 'azure':
       if (!apiEndpoint) {
         throw new Error('API endpoint is required for Azure OpenAI');
       }
       return new AzureOpenAIService(apiKey, apiEndpoint, modelName);
     case 'google':
-      return new GoogleAIService(apiKey, modelName || 'gemini-1.5-pro');
+      return new GoogleAIService(apiKey, modelName || 'gemini-3-pro');
     case 'vertexai':
-      return new VertexAIService(apiKey, 'us-central1', modelName || 'gemini-1.5-pro');
+      return new VertexAIService(apiKey, 'us-central1', modelName || 'gemini-3-pro');
     case 'anthropic':
-      return new AnthropicService(apiKey, modelName || 'claude-3.5-sonnet-20241022');
+      return new AnthropicService(apiKey, modelName || 'claude-sonnet-4-6');
     case 'ollama':
       if (!apiEndpoint) {
         throw new Error('API endpoint is required for Ollama');
       }
-      return new OllamaService(apiEndpoint, modelName);
+      return new OllamaService(apiEndpoint, modelName || 'qwen3');
     default:
       throw new Error(`Unsupported AI provider: ${provider}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,9 @@ import { Comment, CommentThreadStatus, CommentType, GitPullRequestCommentThread 
 import * as fs from 'fs'
 import * as path from 'path'
 import { createAIService } from './ai-services'
-import { getPullRequestDiff, getPullRequestFiles, PullRequestAnalysisTarget } from './pr-utils'
+import { getPullRequestDiff, getPullRequestFiles, getPullRequestContext, PullRequestAnalysisTarget } from './pr-utils'
+import { runHolisticReview, normalizeSeverity } from './review-orchestrator'
+import { postReview } from './review-poster'
 
 async function run() {
   try {
@@ -56,7 +58,31 @@ async function run() {
         
       // Get max file size in lines (defaults to 1500 if not specified)
       const maxFileSizeInLines = parseInt(tl.getInput('maxFileSizeInLines', false) ?? '1500');
-        
+
+      // Review mode: holistic (default) sees the whole PR at once and posts a
+      // summary + line-anchored findings; perFile preserves the legacy loop.
+      const reviewMode = (tl.getInput('reviewMode', false) ?? 'holistic').trim().toLowerCase();
+      if (reviewMode !== 'perfile') {
+        await runHolisticReviewMode(
+          connection,
+          gitApi,
+          repositoryId,
+          pullRequestId,
+          isActive,
+          {
+            aiProvider,
+            apiKey,
+            modelName,
+            apiEndpoint,
+            maxTokens,
+            temperature,
+            maxFileSizeInLines,
+            promptTemplate,
+          }
+        );
+        return;
+      }
+
       try {
         // Get coding standards if specified
         let codingStandards = '';
@@ -348,6 +374,127 @@ function savePromptToFile(prompt: string, aiProvider: string): void {
     console.log(`Prompt saved to: ${filePath}`);
   } catch (error) {
     console.log(`Error saving prompt to file: ${error}`);
+  }
+}
+
+// The legacy per-file default template. In holistic mode this is treated as
+// "not customized" so we use the built-in review instructions instead.
+const DEFAULT_PER_FILE_TEMPLATE = 'Review the following code file and provide constructive feedback:\n\n{diff}';
+
+interface HolisticArgs {
+  aiProvider: string;
+  apiKey: string;
+  modelName: string;
+  apiEndpoint: string;
+  maxTokens: number;
+  temperature: number;
+  maxFileSizeInLines: number;
+  promptTemplate: string;
+}
+
+// Orchestrates a holistic, whole-PR review: gather diffs + context, run the
+// orchestrator, then post a summary thread and line-anchored findings with
+// fingerprint dedup. Never hard-fails the task — malfunctions warn and set
+// SucceededWithIssues.
+async function runHolisticReviewMode(
+  connection: azdev.WebApi,
+  gitApi: any,
+  repositoryId: string,
+  pullRequestId: number,
+  isActive: boolean,
+  args: HolisticArgs
+): Promise<void> {
+  try {
+    // Skip drafts if requested.
+    const skipDraft = tl.getBoolInput('skipDraftPullRequests', false);
+    if (skipDraft) {
+      try {
+        const pr = await gitApi.getPullRequestById(pullRequestId);
+        if (pr?.isDraft) {
+          console.log('Pull request is a draft and skipDraftPullRequests is enabled - skipping review.');
+          return;
+        }
+      } catch (err) {
+        console.log(`Could not determine draft status (continuing): ${err}`);
+      }
+    }
+
+    // Holistic-mode inputs.
+    const minSeverity = normalizeSeverity(tl.getInput('minSeverity', false) ?? 'low');
+    const customInstructions = tl.getInput('customInstructions', false) ?? '';
+    // Default true; only an explicit "false" disables verification.
+    const enableVerification = ((tl.getInput('enableVerification', false) ?? 'true').trim().toLowerCase()) !== 'false';
+    const maxInputTokens = parseInt(tl.getInput('maxInputTokens', false) ?? '200000');
+    const debug = tl.getBoolInput('debug', false);
+
+    // Coding standards (optional).
+    let codingStandards = '';
+    const codingStandardsFile = tl.getPathInput('codingStandardsFile', false);
+    if (codingStandardsFile && tl.filePathSupplied('codingStandardsFile') && fs.existsSync(codingStandardsFile)) {
+      try {
+        codingStandards = fs.readFileSync(codingStandardsFile, 'utf8');
+        console.log(`Read coding standards file (${codingStandards.length} characters)`);
+      } catch (err: any) {
+        console.log(`Could not read coding standards file: ${err.message}`);
+      }
+    }
+
+    // In holistic mode the per-file default template is treated as unset; a
+    // genuinely customized template is used as the base instructions with the
+    // legacy placeholders stripped (holistic assembles its own file block).
+    const holisticTemplate =
+      args.promptTemplate && args.promptTemplate.trim() && args.promptTemplate !== DEFAULT_PER_FILE_TEMPLATE
+        ? args.promptTemplate.replace(/\{diff\}|\{standards\}|\{analysisMode\}/g, '').trim()
+        : undefined;
+
+    // Gather PR context and annotated diffs (changes-only, for line anchoring).
+    console.log('Gathering pull request context and diffs for holistic review...');
+    const context = await getPullRequestContext(connection, repositoryId, pullRequestId);
+    const analysisTargets = await getPullRequestDiff(connection, repositoryId, pullRequestId, undefined, args.maxFileSizeInLines);
+
+    const entries = Object.entries(analysisTargets);
+    if (entries.length === 1 && entries[0][0] === 'ERROR.txt') {
+      const message = entries[0][1]?.content ?? 'No files could be retrieved for analysis';
+      tl.warning(`Holistic review could not run: ${message}`);
+      tl.setResult(tl.TaskResult.SucceededWithIssues, message);
+      return;
+    }
+    if (entries.length === 0) {
+      tl.warning('Holistic review found no files to analyze.');
+      tl.setResult(tl.TaskResult.SucceededWithIssues, 'No files to analyze');
+      return;
+    }
+
+    const aiService = createAIService(args.aiProvider, args.apiKey, args.modelName, args.apiEndpoint);
+
+    const result = await runHolisticReview(aiService, analysisTargets, context, {
+      maxTokens: args.maxTokens,
+      temperature: args.temperature,
+      maxInputTokens,
+      minSeverity,
+      enableVerification,
+      customInstructions,
+      codingStandards,
+      promptTemplate: holisticTemplate,
+      onPrompt: debug ? (label, prompt) => savePromptToFile(`[${label}]\n\n${prompt}`, args.aiProvider) : undefined,
+    });
+
+    if (result.error && result.findings.length === 0 && !result.summary) {
+      tl.warning(`Holistic review malfunctioned: ${result.error}`);
+      tl.setResult(tl.TaskResult.SucceededWithIssues, result.error);
+      return;
+    }
+
+    await postReview(gitApi, repositoryId, pullRequestId, isActive, result);
+
+    if (result.degraded) {
+      tl.warning('Holistic review completed with degraded output (some parts could not be parsed).');
+      tl.setResult(tl.TaskResult.SucceededWithIssues, 'Review completed with degraded output');
+    }
+  } catch (error: any) {
+    // Reviewer is advisory infrastructure — never block the pipeline on a malfunction.
+    tl.warning(`Holistic review error: ${error?.message ?? error}`);
+    tl.setResult(tl.TaskResult.SucceededWithIssues, `Holistic review error: ${error?.message ?? error}`);
   }
 }
 

--- a/src/pr-utils.ts
+++ b/src/pr-utils.ts
@@ -2,17 +2,32 @@ import * as azdev from 'azure-devops-node-api';
 import {
   GitPullRequestIterationChanges,
   VersionControlChangeType,
-  GitVersionType
+  GitVersionType,
+  CommentType
 } from 'azure-devops-node-api/interfaces/GitInterfaces';
 import { Readable } from 'stream';
 import path from 'path';
-import { createTwoFilesPatch } from 'diff';
+import { structuredPatch } from 'diff';
 
 export interface PullRequestAnalysisTarget {
   content: string;
   isDiff: boolean;
   firstChangedLine?: number;
   truncated?: boolean;
+  // Right-file line numbers that were added/modified in this change. These are
+  // the only lines an inline finding may legitimately anchor to. Undefined for
+  // full-file targets (where we don't compute a diff).
+  changedLines?: number[];
+}
+
+// Contextual signals about the PR (beyond the diffs) fed to the holistic
+// reviewer so it can judge intent. Every field is best-effort: a failed fetch
+// yields an empty value rather than aborting the review.
+export interface PullRequestContext {
+  title: string;
+  description: string;
+  workItems: string[];
+  humanComments: string[];
 }
 
 type ChangeEntries = NonNullable<GitPullRequestIterationChanges['changeEntries']>;
@@ -125,18 +140,14 @@ export async function getPullRequestDiff(
         ? await getContentForObjectId(gitApi, repositoryId, project, basePath, baseObjectId)
         : '';
 
-      const patch = createTwoFilesPatch(
+      const annotated = buildAnnotatedDiff(
         basePath || filePath,
         filePath,
         baseContent ?? '',
-        newContent ?? '',
-        '',
-        '',
-        { context: 3 }
+        newContent ?? ''
       );
 
-      const firstChangedLine = extractFirstAddedLine(patch) ?? 1;
-      let diffContent = patch;
+      let diffContent = annotated.text;
       let truncated = false;
 
       const diffLines = diffContent.split('\n');
@@ -149,8 +160,9 @@ export async function getPullRequestDiff(
       fileDiffs[filePath] = {
         content: diffContent,
         isDiff: true,
-        firstChangedLine,
-        truncated
+        firstChangedLine: annotated.firstChangedLine ?? 1,
+        truncated,
+        changedLines: annotated.changedLines
       };
     }
 
@@ -292,14 +304,160 @@ export async function getPullRequestFiles(
   }
 }
 
-function extractFirstAddedLine(patch: string): number | undefined {
-  const match = patch.match(/^\@\@ [^+]*\+(\d+)(?:,(\d+))? \@\@/m);
-  if (!match) {
-    return undefined;
+/**
+ * Builds a unified diff where every emitted line is prefixed with its real
+ * new-file (right-side) line number, and collects the set of right-side line
+ * numbers that were added/modified. The line numbers let the AI cite an exact
+ * line, and `changedLines` lets the orchestrator validate that a cited line is
+ * a legitimate inline anchor (snap/drop otherwise).
+ *
+ * Format per line:
+ *   "   123 + added text"      (addition — anchorable, recorded in changedLines)
+ *   "       - removed text"    (deletion — no right-side line)
+ *   "   123   context text"    (unchanged context)
+ */
+export function buildAnnotatedDiff(
+  oldPath: string,
+  newPath: string,
+  oldStr: string,
+  newStr: string
+): { text: string; changedLines: number[]; firstChangedLine?: number } {
+  const patch = structuredPatch(oldPath, newPath, oldStr, newStr, '', '', { context: 3 });
+  const out: string[] = [];
+  const changedLines: number[] = [];
+  let firstChangedLine: number | undefined;
+
+  for (const hunk of patch.hunks) {
+    out.push(`@@ -${hunk.oldStart},${hunk.oldLines} +${hunk.newStart},${hunk.newLines} @@`);
+    let newLineNo = hunk.newStart;
+
+    for (const raw of hunk.lines) {
+      const marker = raw[0];
+      const text = raw.slice(1);
+
+      if (marker === '+') {
+        out.push(`${String(newLineNo).padStart(6)} + ${text}`);
+        changedLines.push(newLineNo);
+        if (firstChangedLine === undefined) {
+          firstChangedLine = newLineNo;
+        }
+        newLineNo++;
+      } else if (marker === '-') {
+        // Removed line — exists only on the left/base side, no right-file number.
+        out.push(`${' '.repeat(6)} - ${text}`);
+      } else if (marker === '\\') {
+        // "\ No newline at end of file" — metadata, not a real line.
+        out.push(`${' '.repeat(6)}   ${text}`);
+      } else {
+        // Context line (leading space).
+        out.push(`${String(newLineNo).padStart(6)}   ${text}`);
+        newLineNo++;
+      }
+    }
   }
 
-  const parsed = parseInt(match[1], 10);
-  return Number.isNaN(parsed) ? undefined : parsed;
+  return { text: out.join('\n'), changedLines, firstChangedLine };
+}
+
+/**
+ * Best-effort fetch of contextual signals about the PR (title, description,
+ * linked work items, existing human comments) for the holistic reviewer. Each
+ * source is fetched independently; a failure logs a warning and yields an empty
+ * value rather than aborting the review.
+ */
+export async function getPullRequestContext(
+  connection: azdev.WebApi,
+  repositoryId: string,
+  pullRequestId: number,
+  project?: string
+): Promise<PullRequestContext> {
+  const ctx: PullRequestContext = { title: '', description: '', workItems: [], humanComments: [] };
+
+  let gitApi: any;
+  try {
+    gitApi = await connection.getGitApi();
+  } catch (error) {
+    console.log(`⚠️ Could not connect to Git API for PR context: ${error}`);
+    return ctx;
+  }
+
+  // Title + description
+  try {
+    const pr = await gitApi.getPullRequestById(pullRequestId, project);
+    ctx.title = pr?.title ?? '';
+    ctx.description = pr?.description ?? '';
+  } catch (error) {
+    console.log(`⚠️ Could not fetch PR title/description: ${error}`);
+  }
+
+  // Linked work items (acceptance criteria etc.)
+  try {
+    const refs = await gitApi.getPullRequestWorkItemRefs(repositoryId, pullRequestId, project);
+    const ids = (refs ?? [])
+      .map((r: any) => parseInt(r.id, 10))
+      .filter((n: number) => !Number.isNaN(n));
+    if (ids.length > 0) {
+      const witApi = await connection.getWorkItemTrackingApi();
+      const items = await witApi.getWorkItems(
+        ids,
+        ['System.WorkItemType', 'System.Title', 'System.Description', 'Microsoft.VSTS.Common.AcceptanceCriteria']
+      );
+      for (const wi of items ?? []) {
+        const fields = wi.fields ?? {};
+        const type = fields['System.WorkItemType'] ?? 'Work Item';
+        const title = fields['System.Title'] ?? '';
+        const desc = stripHtml(fields['System.Description'] ?? '');
+        const ac = stripHtml(fields['Microsoft.VSTS.Common.AcceptanceCriteria'] ?? '');
+        let entry = `${type} #${wi.id}: ${title}`;
+        if (desc) {
+          entry += `\n  ${desc}`;
+        }
+        if (ac) {
+          entry += `\n  Acceptance criteria: ${ac}`;
+        }
+        ctx.workItems.push(entry);
+      }
+    }
+  } catch (error) {
+    console.log(`⚠️ Could not fetch linked work items: ${error}`);
+  }
+
+  // Existing human comments (skip our own machine-posted threads)
+  try {
+    const threads = await gitApi.getThreads(repositoryId, pullRequestId, project);
+    for (const thread of threads ?? []) {
+      const props = thread.properties ?? {};
+      if (props['PullRequestCommentTask'] || props['AiReviewFinding'] || props['AiReviewSummary']) {
+        continue;
+      }
+      for (const comment of thread.comments ?? []) {
+        if (comment.commentType === CommentType.System) {
+          continue;
+        }
+        const content = (comment.content ?? '').trim();
+        if (content) {
+          ctx.humanComments.push(content);
+        }
+      }
+    }
+  } catch (error) {
+    console.log(`⚠️ Could not fetch existing PR threads: ${error}`);
+  }
+
+  return ctx;
+}
+
+/** Strips HTML tags and decodes the most common entities from work-item fields. */
+function stripHtml(input: string): string {
+  return input
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
 }
 
 async function loadLatestIterationChanges(

--- a/src/review-orchestrator.ts
+++ b/src/review-orchestrator.ts
@@ -1,0 +1,546 @@
+import * as crypto from 'crypto';
+import { AIService } from './ai-services';
+import { PullRequestAnalysisTarget, PullRequestContext } from './pr-utils';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
+
+// What the model is asked to return, before validation/anchoring.
+export interface RawFinding {
+  file: string;
+  line?: number;
+  severity: string;
+  title: string;
+  body: string;
+  // The exact text of the flagged line, used to make the fingerprint stable
+  // across unrelated line-number shifts between runs.
+  snippet?: string;
+}
+
+// A finding after severity normalization, anchor resolution and fingerprinting.
+export interface ResolvedFinding {
+  file: string;
+  line?: number; // resolved right-file anchor; undefined => file-level thread
+  severity: Severity;
+  title: string;
+  body: string;
+  fingerprint: string;
+}
+
+export interface ReviewResult {
+  summary: string;
+  findings: ResolvedFinding[];
+  suppressedCount: number; // findings dropped by the minSeverity filter
+  degraded: boolean;       // true if some/all structured output couldn't be parsed
+  error?: string;          // populated when the pipeline malfunctioned
+}
+
+export interface ReviewOptions {
+  maxTokens: number;        // output token cap per call
+  temperature: number;
+  maxInputTokens: number;   // input budget that drives batching
+  minSeverity: Severity;
+  enableVerification: boolean;
+  customInstructions?: string;
+  codingStandards?: string;
+  // If supplied, used instead of the built-in review instructions. JSON-format
+  // rules are always appended regardless, so a template that dictates a
+  // different output format will degrade to summary-only.
+  promptTemplate?: string;
+  // Optional sink for assembled prompts (debug). Called once per AI call.
+  onPrompt?: (label: string, prompt: string) => void;
+}
+
+interface FileEntry {
+  path: string;
+  target: PullRequestAnalysisTarget;
+}
+
+// ---------------------------------------------------------------------------
+// Severity helpers (pure)
+// ---------------------------------------------------------------------------
+
+const SEVERITY_ORDER: Severity[] = ['info', 'low', 'medium', 'high', 'critical'];
+
+export function normalizeSeverity(value: string | undefined): Severity {
+  const v = (value ?? '').trim().toLowerCase();
+  if (v === 'critical' || v === 'blocker') return 'critical';
+  if (v === 'high' || v === 'major' || v === 'error') return 'high';
+  if (v === 'medium' || v === 'moderate' || v === 'warning' || v === 'warn') return 'medium';
+  if (v === 'low' || v === 'minor') return 'low';
+  if (v === 'info' || v === 'informational' || v === 'nit' || v === 'note') return 'info';
+  // Unknown severities default to medium so they aren't silently filtered out.
+  return 'medium';
+}
+
+export function severityRank(sev: Severity): number {
+  return SEVERITY_ORDER.indexOf(sev);
+}
+
+export function meetsMinSeverity(sev: Severity, min: Severity): boolean {
+  return severityRank(sev) >= severityRank(min);
+}
+
+// ---------------------------------------------------------------------------
+// Token budget + batching (pure)
+// ---------------------------------------------------------------------------
+
+/** Cheap, provider-agnostic token estimate (~4 chars/token). */
+export function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Splits file entries into batches whose combined size stays under
+ * `fileTokenBudget`. A single file larger than the budget gets its own batch
+ * (it will still be sent — truncation already happened upstream in pr-utils).
+ * Pure and order-preserving so it is straightforward to unit test.
+ */
+export function batchEntries(entries: FileEntry[], fileTokenBudget: number): FileEntry[][] {
+  const batches: FileEntry[][] = [];
+  let current: FileEntry[] = [];
+  let currentTokens = 0;
+
+  for (const entry of entries) {
+    const entryTokens = estimateTokens(renderFileBlock(entry));
+    if (current.length > 0 && currentTokens + entryTokens > fileTokenBudget) {
+      batches.push(current);
+      current = [];
+      currentTokens = 0;
+    }
+    current.push(entry);
+    currentTokens += entryTokens;
+  }
+  if (current.length > 0) {
+    batches.push(current);
+  }
+  return batches;
+}
+
+// ---------------------------------------------------------------------------
+// Anchor resolution (pure)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolves the model's cited line to a legitimate inline anchor.
+ *  - No line cited            -> file-level (undefined)
+ *  - No changedLines (full-file target) -> trust the cited line
+ *  - Cited line is a changed line       -> use it
+ *  - Within `snapWindow` of a changed line -> snap to the nearest one
+ *  - Otherwise               -> file-level (undefined)
+ */
+export function resolveAnchor(
+  line: number | undefined,
+  changedLines: number[] | undefined,
+  snapWindow = 5
+): number | undefined {
+  if (line === undefined || line === null || Number.isNaN(line)) {
+    return undefined;
+  }
+  if (!changedLines || changedLines.length === 0) {
+    return line; // full-file target: nothing to validate against
+  }
+  if (changedLines.includes(line)) {
+    return line;
+  }
+  let nearest: number | undefined;
+  let nearestDist = Infinity;
+  for (const cl of changedLines) {
+    const dist = Math.abs(cl - line);
+    if (dist < nearestDist) {
+      nearestDist = dist;
+      nearest = cl;
+    }
+  }
+  if (nearest !== undefined && nearestDist <= snapWindow) {
+    return nearest;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Fingerprint (pure)
+// ---------------------------------------------------------------------------
+
+function normalizeText(text: string): string {
+  return (text ?? '').replace(/\s+/g, ' ').trim().toLowerCase();
+}
+
+/**
+ * Stable fingerprint for cross-run dedup. Deliberately excludes the line number
+ * so a finding survives when unrelated edits shift it up or down a few lines.
+ */
+export function fingerprintFinding(file: string, severity: Severity, title: string, snippet?: string): string {
+  const basis = [
+    file ?? '',
+    severity,
+    normalizeText(title),
+    normalizeText(snippet ?? '')
+  ].join('|');
+  return crypto.createHash('sha1').update(basis).digest('hex').slice(0, 16);
+}
+
+// ---------------------------------------------------------------------------
+// JSON parsing (pure, tolerant)
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts a JSON object from a model response that may be wrapped in markdown
+ * code fences or surrounded by prose. Returns null if no parseable object with
+ * the expected shape is found.
+ */
+export function parseReviewJson(raw: string): { summary: string; findings: RawFinding[] } | null {
+  if (!raw) return null;
+
+  let text = raw.trim();
+
+  // Strip ```json ... ``` or ``` ... ``` fences.
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) {
+    text = fence[1].trim();
+  }
+
+  // Fall back to the outermost {...} span.
+  const candidates: string[] = [text];
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace !== -1 && lastBrace > firstBrace) {
+    candidates.push(text.slice(firstBrace, lastBrace + 1));
+  }
+
+  for (const candidate of candidates) {
+    try {
+      const obj = JSON.parse(candidate);
+      if (obj && typeof obj === 'object') {
+        const summary = typeof obj.summary === 'string' ? obj.summary : '';
+        const findings = Array.isArray(obj.findings) ? (obj.findings as RawFinding[]) : [];
+        if (summary || findings.length > 0) {
+          return { summary, findings };
+        }
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Prompt assembly (pure)
+// ---------------------------------------------------------------------------
+
+const JSON_RULES = `
+Respond with a single JSON object and nothing else (no prose, no markdown fences). Shape:
+{
+  "summary": "A concise overview of the pull request and the most important risks.",
+  "findings": [
+    {
+      "file": "<exact file path as shown>",
+      "line": <the line number shown in the annotated diff for the line the issue is on, or omit for a file-level note>,
+      "severity": "critical | high | medium | low | info",
+      "title": "<short, specific finding title>",
+      "body": "<explanation and suggested fix>",
+      "snippet": "<the exact text of the flagged line, copied verbatim>"
+    }
+  ]
+}
+Rules:
+- Only cite a "line" number that is shown in the annotated diff. Prefer added/changed lines.
+- Report only high-confidence, substantive issues. Prefer silence over speculation. Do not report pure style nits.
+- If there are no issues, return an empty "findings" array and summarize that the change looks sound.`;
+
+const BUILT_IN_INSTRUCTIONS = `You are a senior software engineer performing a holistic review of an Azure DevOps pull request. You can see all of the changed files together; reason across files, not just within each one. Judge whether the change matches its stated intent, look for correctness bugs, security issues, broken contracts, and missing edge cases.`;
+
+export function renderContextBlock(context: PullRequestContext, codingStandards?: string): string {
+  const parts: string[] = [];
+  if (context.title) {
+    parts.push(`## Pull request title\n${context.title}`);
+  }
+  if (context.description) {
+    parts.push(`## Pull request description\n${context.description}`);
+  }
+  if (context.workItems && context.workItems.length > 0) {
+    parts.push(`## Linked work items\n${context.workItems.join('\n\n')}`);
+  }
+  if (codingStandards && codingStandards.trim()) {
+    parts.push(`## Coding standards\n${codingStandards.trim()}`);
+  }
+  if (context.humanComments && context.humanComments.length > 0) {
+    parts.push(
+      `## Existing human review comments (do not repeat points already raised)\n` +
+        context.humanComments.map((c) => `- ${c}`).join('\n')
+    );
+  }
+  return parts.join('\n\n');
+}
+
+function renderFileBlock(entry: FileEntry): string {
+  return `### File: ${entry.path}\n${entry.target.content}`;
+}
+
+export function buildReviewPrompt(
+  contextBlock: string,
+  filesBlock: string,
+  options: ReviewOptions
+): string {
+  const base = options.promptTemplate && options.promptTemplate.trim()
+    ? options.promptTemplate.trim()
+    : BUILT_IN_INSTRUCTIONS;
+
+  const sections = [base];
+  if (options.customInstructions && options.customInstructions.trim()) {
+    sections.push(`## Additional instructions\n${options.customInstructions.trim()}`);
+  }
+  if (contextBlock) {
+    sections.push(contextBlock);
+  }
+  sections.push(`## Changed files\n${filesBlock}`);
+  sections.push(JSON_RULES);
+  return sections.join('\n\n');
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+// Rough allowance (tokens) reserved for the instructions/context wrapper so the
+// file budget doesn't blow the input window.
+const PROMPT_OVERHEAD_TOKENS = 1500;
+
+export async function runHolisticReview(
+  aiService: AIService,
+  analysisTargets: Record<string, PullRequestAnalysisTarget>,
+  context: PullRequestContext,
+  options: ReviewOptions
+): Promise<ReviewResult> {
+  const entries: FileEntry[] = Object.entries(analysisTargets)
+    .filter(([path, target]) => path !== 'ERROR.txt' && target && target.content)
+    .map(([path, target]) => ({ path, target }));
+
+  if (entries.length === 0) {
+    return { summary: '', findings: [], suppressedCount: 0, degraded: false, error: 'No files to review' };
+  }
+
+  const contextBlock = renderContextBlock(context, options.codingStandards);
+  const contextTokens = estimateTokens(contextBlock);
+  const fileTokenBudget = Math.max(
+    1000,
+    options.maxInputTokens - contextTokens - PROMPT_OVERHEAD_TOKENS
+  );
+
+  const batches = batchEntries(entries, fileTokenBudget);
+
+  const rawFindings: RawFinding[] = [];
+  const batchSummaries: string[] = [];
+  let anyParsed = false;
+  let anyFailed = false;
+
+  for (let i = 0; i < batches.length; i++) {
+    const batch = batches[i];
+    const filesBlock = batch.map(renderFileBlock).join('\n\n');
+    const prompt = buildReviewPrompt(contextBlock, filesBlock, options);
+    const label = batches.length > 1 ? `review batch ${i + 1}/${batches.length}` : 'review';
+    if (options.onPrompt) options.onPrompt(label, prompt);
+
+    const parsed = await callAndParse(aiService, prompt, options);
+    if (parsed) {
+      anyParsed = true;
+      rawFindings.push(...parsed.findings);
+      if (parsed.summary) batchSummaries.push(parsed.summary);
+    } else {
+      anyFailed = true;
+    }
+  }
+
+  if (!anyParsed) {
+    // Nothing parsed at all -> degrade to a summary-only note.
+    return {
+      summary: 'The AI reviewer could not produce a structured review for this pull request.',
+      findings: [],
+      suppressedCount: 0,
+      degraded: true,
+      error: 'Failed to parse structured review output'
+    };
+  }
+
+  // Resolve, fingerprint and internally dedup the candidates.
+  const resolved = resolveFindings(rawFindings, analysisTargets);
+  const deduped = dedupeByFingerprint(resolved);
+
+  // Optional verification (false-positive suppression). Runs once over the
+  // merged candidate set. Fails open: a verification glitch keeps the findings.
+  let verified = deduped;
+  if (options.enableVerification && deduped.length > 0) {
+    verified = await verifyFindings(aiService, deduped, contextBlock, options);
+  }
+
+  // minSeverity filter (count suppressed for the summary).
+  const kept: ResolvedFinding[] = [];
+  let suppressedCount = 0;
+  for (const f of verified) {
+    if (meetsMinSeverity(f.severity, options.minSeverity)) {
+      kept.push(f);
+    } else {
+      suppressedCount++;
+    }
+  }
+
+  // Summary: single batch reuses its summary; multiple batches get a synthesis.
+  let summary: string;
+  if (batchSummaries.length <= 1) {
+    summary = batchSummaries[0] ?? '';
+  } else {
+    summary = await synthesizeSummary(aiService, batchSummaries, kept, options);
+  }
+
+  return {
+    summary,
+    findings: kept,
+    suppressedCount,
+    degraded: anyFailed,
+  };
+}
+
+/** Calls the model in JSON mode, parsing with one retry before giving up. */
+async function callAndParse(
+  aiService: AIService,
+  prompt: string,
+  options: ReviewOptions
+): Promise<{ summary: string; findings: RawFinding[] } | null> {
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const response = await aiService.generateComment(prompt, options.maxTokens, options.temperature, { jsonMode: true });
+    if (response.error) {
+      console.log(`AI call error (attempt ${attempt + 1}): ${response.error}`);
+      continue;
+    }
+    const parsed = parseReviewJson(response.content);
+    if (parsed) {
+      return parsed;
+    }
+    console.log(`Could not parse structured output (attempt ${attempt + 1}).`);
+  }
+  return null;
+}
+
+function resolveFindings(
+  raw: RawFinding[],
+  analysisTargets: Record<string, PullRequestAnalysisTarget>
+): ResolvedFinding[] {
+  const out: ResolvedFinding[] = [];
+  for (const f of raw) {
+    if (!f || !f.file || !f.title) continue;
+    const target = analysisTargets[f.file];
+    const severity = normalizeSeverity(f.severity);
+    const line = resolveAnchor(
+      typeof f.line === 'number' ? f.line : undefined,
+      target?.changedLines
+    );
+    out.push({
+      file: f.file,
+      line,
+      severity,
+      title: f.title,
+      body: f.body ?? '',
+      fingerprint: fingerprintFinding(f.file, severity, f.title, f.snippet)
+    });
+  }
+  return out;
+}
+
+export function dedupeByFingerprint(findings: ResolvedFinding[]): ResolvedFinding[] {
+  const seen = new Set<string>();
+  const out: ResolvedFinding[] = [];
+  for (const f of findings) {
+    if (seen.has(f.fingerprint)) continue;
+    seen.add(f.fingerprint);
+    out.push(f);
+  }
+  return out;
+}
+
+/**
+ * Critic pass: asks the model to confirm which candidate findings are real.
+ * Returns the surviving findings. Fails open (keeps everything) on any error.
+ */
+async function verifyFindings(
+  aiService: AIService,
+  findings: ResolvedFinding[],
+  contextBlock: string,
+  options: ReviewOptions
+): Promise<ResolvedFinding[]> {
+  const list = findings
+    .map((f, idx) => `${idx}. [${f.severity}] ${f.file}${f.line ? `:${f.line}` : ''} — ${f.title}\n   ${f.body}`)
+    .join('\n');
+
+  const prompt = `${contextBlock ? contextBlock + '\n\n' : ''}You previously proposed the following code-review findings for this pull request. For each one, decide whether it is a genuine, high-confidence issue. Drop anything speculative, incorrect, or that you are unsure about.
+
+Findings:
+${list}
+
+Respond with a single JSON object and nothing else:
+{ "confirmed": [<indices of the findings that are definitely real>] }`;
+
+  if (options.onPrompt) options.onPrompt('verification', prompt);
+
+  const response = await aiService.generateComment(prompt, options.maxTokens, options.temperature, { jsonMode: true });
+  if (response.error) {
+    console.log(`Verification call failed, keeping all findings: ${response.error}`);
+    return findings;
+  }
+
+  const confirmed = parseConfirmedIndices(response.content);
+  if (confirmed === null) {
+    console.log('Could not parse verification output, keeping all findings.');
+    return findings;
+  }
+
+  const keepSet = new Set(confirmed);
+  const survivors = findings.filter((_, idx) => keepSet.has(idx));
+  console.log(`Verification kept ${survivors.length}/${findings.length} findings.`);
+  return survivors;
+}
+
+export function parseConfirmedIndices(raw: string): number[] | null {
+  if (!raw) return null;
+  let text = raw.trim();
+  const fence = text.match(/```(?:json)?\s*([\s\S]*?)```/i);
+  if (fence) text = fence[1].trim();
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  const candidate = firstBrace !== -1 && lastBrace > firstBrace ? text.slice(firstBrace, lastBrace + 1) : text;
+  try {
+    const obj = JSON.parse(candidate);
+    if (obj && Array.isArray(obj.confirmed)) {
+      return obj.confirmed
+        .map((n: any) => parseInt(n, 10))
+        .filter((n: number) => !Number.isNaN(n));
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+/** Writes a unified summary across batches. Falls back to concatenation. */
+async function synthesizeSummary(
+  aiService: AIService,
+  batchSummaries: string[],
+  findings: ResolvedFinding[],
+  options: ReviewOptions
+): Promise<string> {
+  const prompt = `You reviewed a large pull request in several parts. Merge the partial summaries below into one concise overall summary of the pull request and its most important risks. Do not list individual findings; they are posted separately.
+
+Partial summaries:
+${batchSummaries.map((s, i) => `Part ${i + 1}: ${s}`).join('\n\n')}`;
+
+  if (options.onPrompt) options.onPrompt('synthesis', prompt);
+
+  const response = await aiService.generateComment(prompt, options.maxTokens, options.temperature);
+  if (response.error || !response.content) {
+    return batchSummaries.join('\n\n');
+  }
+  return response.content.trim();
+}

--- a/src/review-poster.ts
+++ b/src/review-poster.ts
@@ -1,0 +1,169 @@
+import {
+  CommentThreadStatus,
+  CommentType,
+  GitPullRequestCommentThread,
+} from 'azure-devops-node-api/interfaces/GitInterfaces';
+import { ResolvedFinding, ReviewResult, Severity } from './review-orchestrator';
+
+// Thread property keys used to recognize our own machine-posted threads on
+// re-runs. Kept here so pr-utils (which filters human comments) and the poster
+// agree on the same markers.
+export const SUMMARY_PROPERTY = 'AiReviewSummary';
+export const FINDING_PROPERTY = 'AiReviewFinding';
+export const FINGERPRINT_PROPERTY = 'AiFindingFingerprint';
+
+export const SEVERITY_LABELS: Record<Severity, string> = {
+  critical: '🔴 CRITICAL',
+  high: '🟠 HIGH',
+  medium: '🟡 MEDIUM',
+  low: '🔵 LOW',
+  info: '⚪ INFO',
+};
+
+export function formatFindingComment(finding: ResolvedFinding): string {
+  return `**${SEVERITY_LABELS[finding.severity]}: ${finding.title}**\n\n${finding.body}`;
+}
+
+export function formatSummaryComment(result: ReviewResult): string {
+  let content = `**🤖 AI Pull Request Review**\n\n${result.summary || 'No summary was produced.'}`;
+  content += `\n\n_${result.findings.length} finding(s) posted._`;
+  if (result.suppressedCount > 0) {
+    content += ` _${result.suppressedCount} lower-severity finding(s) suppressed by the minimum-severity filter._`;
+  }
+  return content;
+}
+
+// A structural subset of the Git API surface the poster uses. Lets tests pass a
+// lightweight fake without depending on the full azure-devops-node-api client.
+export interface GitApiLike {
+  getThreads(repositoryId: string, pullRequestId: number): Promise<GitPullRequestCommentThread[] | undefined>;
+  createThread(thread: GitPullRequestCommentThread, repositoryId: string, pullRequestId: number): Promise<any>;
+  updateThread(
+    thread: GitPullRequestCommentThread,
+    repositoryId: string,
+    pullRequestId: number,
+    threadId: number
+  ): Promise<any>;
+  updateComment(
+    comment: { commentType: CommentType; content: string },
+    repositoryId: string,
+    pullRequestId: number,
+    threadId: number,
+    commentId: number
+  ): Promise<any>;
+}
+
+/**
+ * Posts the holistic review to the PR:
+ *  - the summary thread, updated in place if it already exists;
+ *  - each finding, skipped if an open thread with the same fingerprint exists;
+ *  - threads for findings that no longer appear are closed (stale resolution).
+ *
+ * Every Git call is individually guarded so one failure doesn't abort the rest.
+ */
+export async function postReview(
+  gitApi: GitApiLike,
+  repositoryId: string,
+  pullRequestId: number,
+  isActive: boolean,
+  result: ReviewResult
+): Promise<void> {
+  const threadStatus = isActive ? CommentThreadStatus.Active : CommentThreadStatus.Closed;
+
+  let existingThreads: GitPullRequestCommentThread[] = [];
+  try {
+    existingThreads = (await gitApi.getThreads(repositoryId, pullRequestId)) ?? [];
+  } catch (err) {
+    console.log(`Could not fetch existing threads (continuing): ${err}`);
+  }
+
+  // ---- Summary thread (update in place if present) ----
+  const summaryContent = formatSummaryComment(result);
+  const existingSummary = existingThreads.find((t) => t.properties && t.properties[SUMMARY_PROPERTY]);
+  if (existingSummary && existingSummary.id && existingSummary.comments && existingSummary.comments[0]?.id) {
+    try {
+      await gitApi.updateComment(
+        { commentType: CommentType.Text, content: summaryContent },
+        repositoryId,
+        pullRequestId,
+        existingSummary.id,
+        existingSummary.comments[0].id!
+      );
+      console.log('Updated existing review summary.');
+    } catch (err) {
+      console.log(`Could not update summary thread: ${err}`);
+    }
+  } else {
+    const summaryThread: GitPullRequestCommentThread = {
+      comments: [{ commentType: CommentType.Text, content: summaryContent }],
+      status: threadStatus,
+      properties: { [SUMMARY_PROPERTY]: 'true' },
+    };
+    try {
+      await gitApi.createThread(summaryThread, repositoryId, pullRequestId);
+      console.log('Posted review summary.');
+    } catch (err) {
+      console.log(`Could not post summary thread: ${err}`);
+    }
+  }
+
+  // ---- Findings: dedup against existing, post new, close stale ----
+  const existingFindingThreads = existingThreads.filter(
+    (t) => t.properties && t.properties[FINGERPRINT_PROPERTY]
+  );
+  const openByFingerprint = new Map<string, GitPullRequestCommentThread>();
+  for (const t of existingFindingThreads) {
+    const fp = t.properties![FINGERPRINT_PROPERTY] as unknown as string;
+    if (t.status !== CommentThreadStatus.Closed) {
+      openByFingerprint.set(fp, t);
+    }
+  }
+
+  const currentFingerprints = new Set(result.findings.map((f) => f.fingerprint));
+
+  for (const finding of result.findings) {
+    if (openByFingerprint.has(finding.fingerprint)) {
+      console.log(`Finding already posted, skipping: ${finding.title}`);
+      continue;
+    }
+
+    const threadContext: any = finding.line
+      ? {
+          filePath: finding.file,
+          rightFileStart: { line: finding.line, offset: 1 },
+          rightFileEnd: { line: finding.line, offset: 1 },
+        }
+      : { filePath: finding.file };
+
+    const thread: GitPullRequestCommentThread = {
+      comments: [{ commentType: CommentType.Text, content: formatFindingComment(finding) }],
+      status: threadStatus,
+      threadContext,
+      properties: { [FINDING_PROPERTY]: 'true', [FINGERPRINT_PROPERTY]: finding.fingerprint },
+    };
+
+    try {
+      await gitApi.createThread(thread, repositoryId, pullRequestId);
+      console.log(`Posted finding (${finding.severity}) on ${finding.file}${finding.line ? `:${finding.line}` : ''}`);
+    } catch (err) {
+      console.log(`Could not post finding for ${finding.file}: ${err}`);
+    }
+  }
+
+  // Close threads whose finding no longer appears in this run.
+  for (const [fingerprint, thread] of openByFingerprint.entries()) {
+    if (currentFingerprints.has(fingerprint)) continue;
+    if (!thread.id) continue;
+    try {
+      await gitApi.updateThread(
+        { status: CommentThreadStatus.Closed },
+        repositoryId,
+        pullRequestId,
+        thread.id
+      );
+      console.log(`Closed stale finding thread ${thread.id}.`);
+    } catch (err) {
+      console.log(`Could not close stale thread ${thread.id}: ${err}`);
+    }
+  }
+}

--- a/src/task.json
+++ b/src/task.json
@@ -54,7 +54,7 @@
         "label": "Model Name",
         "defaultValue": "",
         "required": false,
-        "helpMarkDown": "Specify the model name to use (e.g., gpt-4o, claude-3.5-sonnet-20241022, gemini-1.5-pro). Leave empty to use provider defaults.",
+        "helpMarkDown": "Specify the model name to use (e.g., gpt-5.4, claude-sonnet-4-6, gemini-3-pro, qwen3). Leave empty to use provider defaults.",
         "visibleRule": "useAIGeneration == true"
       },
       {
@@ -109,10 +109,10 @@
       {
         "name": "maxTokens",
         "type": "string",
-        "label": "Max Tokens",
-        "defaultValue": "1000",
+        "label": "Max Output Tokens",
+        "defaultValue": "8000",
         "required": false,
-        "helpMarkDown": "Maximum number of tokens for the AI response",
+        "helpMarkDown": "Maximum number of tokens for the AI response. Holistic reviews need headroom for a summary plus multiple findings.",
         "visibleRule": "useAIGeneration == true"
       },
       {
@@ -139,7 +139,85 @@
         "defaultValue": false,
         "label": "Analyze changed lines only",
         "required": false,
-        "helpMarkDown": "If checked, only the changed lines in the pull request will be analyzed. Otherwise the full file content is used.",
+        "helpMarkDown": "If checked, only the changed lines in the pull request will be analyzed. Otherwise the full file content is used. (Per-file mode only; holistic review always uses annotated diffs.)",
+        "visibleRule": "useAIGeneration == true && reviewMode == perFile"
+      },
+      {
+        "name": "reviewMode",
+        "type": "pickList",
+        "label": "Review Mode",
+        "defaultValue": "holistic",
+        "required": false,
+        "helpMarkDown": "Holistic: the AI sees the whole pull request at once and posts a summary plus line-anchored findings with severity (recommended). Per-file: the legacy behaviour that comments on each file independently.",
+        "options": {
+          "holistic": "Holistic (whole-PR review)",
+          "perFile": "Per-file (legacy)"
+        },
+        "visibleRule": "useAIGeneration == true"
+      },
+      {
+        "name": "minSeverity",
+        "type": "pickList",
+        "label": "Minimum Severity",
+        "defaultValue": "low",
+        "required": false,
+        "helpMarkDown": "Findings below this severity are not posted (their count is noted in the summary). Holistic mode only.",
+        "options": {
+          "info": "Info",
+          "low": "Low",
+          "medium": "Medium",
+          "high": "High",
+          "critical": "Critical"
+        },
+        "visibleRule": "useAIGeneration == true && reviewMode != perFile"
+      },
+      {
+        "name": "customInstructions",
+        "type": "multiLine",
+        "properties": {
+          "resizable": true,
+          "rows": "3"
+        },
+        "label": "Custom Review Instructions",
+        "defaultValue": "",
+        "required": false,
+        "helpMarkDown": "Optional free-text guidance injected into the holistic review prompt (e.g. 'Focus on security; this is a React 18 codebase'). Do not use this to dictate output format.",
+        "visibleRule": "useAIGeneration == true && reviewMode != perFile"
+      },
+      {
+        "name": "enableVerification",
+        "type": "boolean",
+        "defaultValue": true,
+        "label": "Enable verification pass",
+        "required": false,
+        "helpMarkDown": "If checked, candidate findings are sent back to the model for a confirm-or-drop critic pass to suppress false positives (roughly doubles token cost). Holistic mode only.",
+        "visibleRule": "useAIGeneration == true && reviewMode != perFile"
+      },
+      {
+        "name": "maxInputTokens",
+        "type": "string",
+        "label": "Max Input Tokens",
+        "defaultValue": "200000",
+        "required": false,
+        "helpMarkDown": "Approximate input budget (chars/4) for the holistic review. Pull requests larger than this are split into batches that are reviewed separately and then synthesised.",
+        "visibleRule": "useAIGeneration == true && reviewMode != perFile"
+      },
+      {
+        "name": "skipDraftPullRequests",
+        "type": "boolean",
+        "defaultValue": false,
+        "label": "Skip draft pull requests",
+        "required": false,
+        "helpMarkDown": "If checked, the holistic review is skipped for pull requests marked as draft.",
+        "visibleRule": "useAIGeneration == true && reviewMode != perFile"
+      },
+      {
+        "name": "debug",
+        "type": "boolean",
+        "defaultValue": false,
+        "label": "Debug (save prompts to disk)",
+        "required": false,
+        "helpMarkDown": "If checked, assembled prompts are written to the agent temp directory for troubleshooting.",
         "visibleRule": "useAIGeneration == true"
       },
       {

--- a/tests/holistic-review.test.ts
+++ b/tests/holistic-review.test.ts
@@ -1,0 +1,229 @@
+import { test, expect, describe } from 'bun:test';
+import { runHolisticReview, ReviewOptions } from '../src/review-orchestrator';
+import { AIService, AIGenerateOptions, AIResponse } from '../src/ai-services';
+import { PullRequestAnalysisTarget, PullRequestContext } from '../src/pr-utils';
+
+// ---------------------------------------------------------------------------
+// Programmable fake AIService. Routes by prompt content so a single fake can
+// serve the review, verification and synthesis calls the orchestrator makes.
+// ---------------------------------------------------------------------------
+class FakeAIService implements AIService {
+  calls: { prompt: string; jsonMode?: boolean }[] = [];
+  private reviewResponses: string[];
+  private reviewIndex = 0;
+  verifyResponder: (prompt: string) => string = () => '{"confirmed":[]}';
+  synthResponder: (prompt: string) => string = () => 'synthesized summary';
+
+  constructor(reviewResponses: string[]) {
+    this.reviewResponses = reviewResponses;
+  }
+
+  async generateComment(
+    prompt: string,
+    _maxTokens: number,
+    _temperature: number,
+    options?: AIGenerateOptions
+  ): Promise<AIResponse> {
+    this.calls.push({ prompt, jsonMode: options?.jsonMode });
+    if (prompt.includes('Merge the partial summaries')) {
+      return { content: this.synthResponder(prompt) };
+    }
+    if (prompt.includes('decide whether it is a genuine')) {
+      return { content: this.verifyResponder(prompt) };
+    }
+    const r = this.reviewResponses[this.reviewIndex++] ?? '{"summary":"","findings":[]}';
+    return { content: r };
+  }
+
+  reviewCalls() {
+    return this.calls.filter(
+      (c) => !c.prompt.includes('Merge the partial summaries') && !c.prompt.includes('decide whether it is a genuine')
+    );
+  }
+  verifyCalls() {
+    return this.calls.filter((c) => c.prompt.includes('decide whether it is a genuine'));
+  }
+  synthCalls() {
+    return this.calls.filter((c) => c.prompt.includes('Merge the partial summaries'));
+  }
+}
+
+const emptyContext: PullRequestContext = { title: '', description: '', workItems: [], humanComments: [] };
+
+function target(content: string, changedLines?: number[]): PullRequestAnalysisTarget {
+  return { content, isDiff: true, firstChangedLine: changedLines?.[0], changedLines };
+}
+
+function opts(overrides: Partial<ReviewOptions> = {}): ReviewOptions {
+  return {
+    maxTokens: 4000,
+    temperature: 0.2,
+    maxInputTokens: 200000,
+    minSeverity: 'low',
+    enableVerification: false,
+    ...overrides,
+  };
+}
+
+function review(summary: string, findings: any[]): string {
+  return JSON.stringify({ summary, findings });
+}
+
+describe('runHolisticReview — happy path', () => {
+  test('single batch produces summary + anchored finding, one AI call', async () => {
+    const ai = new FakeAIService([
+      review('looks reasonable', [
+        { file: 'src/a.ts', line: 10, severity: 'high', title: 'Null deref', body: 'fix it', snippet: 'x.y' },
+      ]),
+    ]);
+    const targets = { 'src/a.ts': target('   10 + x.y', [10]) };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts());
+
+    expect(result.summary).toBe('looks reasonable');
+    expect(result.findings.length).toBe(1);
+    expect(result.findings[0].line).toBe(10); // anchored to a changed line
+    expect(result.findings[0].severity).toBe('high');
+    expect(result.findings[0].fingerprint).toBeTruthy();
+    expect(result.suppressedCount).toBe(0);
+    expect(result.degraded).toBe(false);
+    expect(ai.reviewCalls().length).toBe(1);
+    expect(ai.reviewCalls()[0].jsonMode).toBe(true); // structured output requested
+  });
+});
+
+describe('runHolisticReview — minSeverity filter', () => {
+  test('drops findings below threshold and counts them', async () => {
+    const ai = new FakeAIService([
+      review('s', [
+        { file: 'src/a.ts', line: 10, severity: 'high', title: 'Big', body: '', snippet: 'a' },
+        { file: 'src/a.ts', line: 10, severity: 'low', title: 'Tiny', body: '', snippet: 'b' },
+      ]),
+    ]);
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts({ minSeverity: 'medium' }));
+
+    expect(result.findings.length).toBe(1);
+    expect(result.findings[0].title).toBe('Big');
+    expect(result.suppressedCount).toBe(1);
+  });
+});
+
+describe('runHolisticReview — anchor resolution', () => {
+  test('snaps near-misses and drops far-off cited lines to file-level', async () => {
+    const ai = new FakeAIService([
+      review('s', [
+        { file: 'src/a.ts', line: 12, severity: 'high', title: 'Near', body: '', snippet: 'a' },
+        { file: 'src/a.ts', line: 999, severity: 'high', title: 'Far', body: '', snippet: 'b' },
+      ]),
+    ]);
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts());
+
+    const near = result.findings.find((f) => f.title === 'Near')!;
+    const far = result.findings.find((f) => f.title === 'Far')!;
+    expect(near.line).toBe(10); // snapped to nearest changed line within window
+    expect(far.line).toBeUndefined(); // dropped to file-level
+  });
+});
+
+describe('runHolisticReview — verification pass', () => {
+  test('keeps only confirmed findings', async () => {
+    const ai = new FakeAIService([
+      review('s', [
+        { file: 'src/a.ts', line: 10, severity: 'high', title: 'Real', body: '', snippet: 'a' },
+        { file: 'src/a.ts', line: 10, severity: 'high', title: 'Bogus', body: '', snippet: 'b' },
+      ]),
+    ]);
+    ai.verifyResponder = () => '{"confirmed":[0]}'; // keep only the first
+
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+    const result = await runHolisticReview(ai, targets, emptyContext, opts({ enableVerification: true }));
+
+    expect(ai.verifyCalls().length).toBe(1);
+    expect(result.findings.length).toBe(1);
+    expect(result.findings[0].title).toBe('Real');
+  });
+
+  test('fails open: a broken verification response keeps all findings', async () => {
+    const ai = new FakeAIService([
+      review('s', [{ file: 'src/a.ts', line: 10, severity: 'high', title: 'A', body: '', snippet: 'a' }]),
+    ]);
+    ai.verifyResponder = () => 'garbage not json';
+
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+    const result = await runHolisticReview(ai, targets, emptyContext, opts({ enableVerification: true }));
+
+    expect(result.findings.length).toBe(1);
+  });
+});
+
+describe('runHolisticReview — parse robustness', () => {
+  test('malformed output then valid on retry still succeeds (not degraded)', async () => {
+    const ai = new FakeAIService(['this is not json', review('recovered', [])]);
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts());
+
+    expect(result.summary).toBe('recovered');
+    expect(result.degraded).toBe(false);
+    expect(ai.reviewCalls().length).toBe(2); // one retry
+  });
+
+  test('two failed attempts degrade to a summary-only result', async () => {
+    const ai = new FakeAIService(['nope', 'still nope']);
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts());
+
+    expect(result.degraded).toBe(true);
+    expect(result.error).toBeTruthy();
+    expect(result.findings.length).toBe(0);
+  });
+});
+
+describe('runHolisticReview — dedup', () => {
+  test('identical findings within a run are deduped', async () => {
+    const dup = { file: 'src/a.ts', line: 10, severity: 'high', title: 'Same', body: 'x', snippet: 'a' };
+    const ai = new FakeAIService([review('s', [dup, { ...dup }])]);
+    const targets = { 'src/a.ts': target('   10 + a', [10]) };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts());
+    expect(result.findings.length).toBe(1);
+  });
+});
+
+describe('runHolisticReview — large PR batching + synthesis', () => {
+  test('splits oversized PR into batches and synthesizes one summary', async () => {
+    const big = 'x'.repeat(6000); // ~1500 tokens each, forces a per-file split
+    const ai = new FakeAIService([
+      review('part one', [{ file: 'src/a.ts', line: 1, severity: 'high', title: 'A', body: '', snippet: 'a' }]),
+      review('part two', [{ file: 'src/b.ts', line: 1, severity: 'high', title: 'B', body: '', snippet: 'b' }]),
+    ]);
+    ai.synthResponder = () => 'unified summary';
+
+    const targets = {
+      'src/a.ts': target(`    1 + ${big}`, [1]),
+      'src/b.ts': target(`    1 + ${big}`, [1]),
+    };
+
+    const result = await runHolisticReview(ai, targets, emptyContext, opts({ maxInputTokens: 2000 }));
+
+    expect(ai.reviewCalls().length).toBe(2); // two batches
+    expect(ai.synthCalls().length).toBe(1); // synthesized
+    expect(result.summary).toBe('unified summary');
+    expect(result.findings.map((f) => f.title).sort()).toEqual(['A', 'B']);
+  });
+});
+
+describe('runHolisticReview — no files', () => {
+  test('returns an error result when there is nothing to review', async () => {
+    const ai = new FakeAIService([]);
+    const result = await runHolisticReview(ai, {}, emptyContext, opts());
+    expect(result.error).toBeTruthy();
+    expect(result.findings.length).toBe(0);
+    expect(ai.calls.length).toBe(0); // never calls the model
+  });
+});

--- a/tests/pr-utils.test.ts
+++ b/tests/pr-utils.test.ts
@@ -1,0 +1,40 @@
+import { test, expect, describe } from 'bun:test';
+import { buildAnnotatedDiff } from '../src/pr-utils';
+
+describe('buildAnnotatedDiff', () => {
+  test('annotates added lines with real right-file line numbers and records them as changed', () => {
+    const oldStr = 'line1\nline2\nline3\n';
+    const newStr = 'line1\nline2\nINSERTED\nline3\n';
+    const { text, changedLines, firstChangedLine } = buildAnnotatedDiff('f', 'f', oldStr, newStr);
+
+    // The inserted line becomes new-file line 3.
+    expect(changedLines).toContain(3);
+    expect(firstChangedLine).toBe(3);
+    // The annotated text shows the line number next to the '+' marker.
+    expect(text).toMatch(/3 \+ INSERTED/);
+  });
+
+  test('removed lines do not appear in changedLines', () => {
+    const oldStr = 'a\nb\nc\n';
+    const newStr = 'a\nc\n';
+    const { text, changedLines } = buildAnnotatedDiff('f', 'f', oldStr, newStr);
+    // 'b' was removed; nothing was added, so there are no right-side changed lines.
+    expect(changedLines.length).toBe(0);
+    expect(text).toMatch(/- b/);
+  });
+
+  test('modified line records the new line number', () => {
+    const oldStr = 'header\nvalue = 1\nfooter\n';
+    const newStr = 'header\nvalue = 2\nfooter\n';
+    const { changedLines } = buildAnnotatedDiff('f', 'f', oldStr, newStr);
+    // 'value = 2' is the addition at new-file line 2.
+    expect(changedLines).toContain(2);
+  });
+
+  test('no changes yields empty changed lines', () => {
+    const same = 'x\ny\nz\n';
+    const { changedLines, firstChangedLine } = buildAnnotatedDiff('f', 'f', same, same);
+    expect(changedLines.length).toBe(0);
+    expect(firstChangedLine).toBeUndefined();
+  });
+});

--- a/tests/review-orchestrator.test.ts
+++ b/tests/review-orchestrator.test.ts
@@ -1,0 +1,183 @@
+import { test, expect, describe } from 'bun:test';
+import {
+  estimateTokens,
+  batchEntries,
+  resolveAnchor,
+  normalizeSeverity,
+  severityRank,
+  meetsMinSeverity,
+  fingerprintFinding,
+  parseReviewJson,
+  parseConfirmedIndices,
+  dedupeByFingerprint,
+  ResolvedFinding,
+} from '../src/review-orchestrator';
+
+// Minimal FileEntry shape (batchEntries only reads path + target.content).
+function entry(path: string, content: string): any {
+  return { path, target: { content, isDiff: true } };
+}
+
+describe('estimateTokens', () => {
+  test('approximates ~4 chars per token', () => {
+    expect(estimateTokens('')).toBe(0);
+    expect(estimateTokens('abcd')).toBe(1);
+    expect(estimateTokens('abcde')).toBe(2);
+  });
+});
+
+describe('batchEntries', () => {
+  test('keeps everything in one batch when under budget', () => {
+    const entries = [entry('a.ts', 'x'.repeat(40)), entry('b.ts', 'y'.repeat(40))];
+    const batches = batchEntries(entries, 10000);
+    expect(batches.length).toBe(1);
+    expect(batches[0].length).toBe(2);
+  });
+
+  test('splits into multiple batches when over budget', () => {
+    // Each rendered block is well over 5 tokens; budget of 5 forces a split per file.
+    const entries = [
+      entry('a.ts', 'x'.repeat(400)),
+      entry('b.ts', 'y'.repeat(400)),
+      entry('c.ts', 'z'.repeat(400)),
+    ];
+    const batches = batchEntries(entries, 5);
+    expect(batches.length).toBe(3);
+  });
+
+  test('preserves order across batches', () => {
+    const entries = [entry('a.ts', 'x'.repeat(400)), entry('b.ts', 'y'.repeat(400))];
+    const batches = batchEntries(entries, 5);
+    expect(batches[0][0].path).toBe('a.ts');
+    expect(batches[1][0].path).toBe('b.ts');
+  });
+
+  test('an oversized single file still gets its own batch', () => {
+    const batches = batchEntries([entry('big.ts', 'x'.repeat(100000))], 5);
+    expect(batches.length).toBe(1);
+    expect(batches[0][0].path).toBe('big.ts');
+  });
+});
+
+describe('resolveAnchor', () => {
+  const changed = [10, 11, 20, 21];
+
+  test('no line cited -> file-level (undefined)', () => {
+    expect(resolveAnchor(undefined, changed)).toBeUndefined();
+  });
+
+  test('full-file target (no changedLines) trusts the cited line', () => {
+    expect(resolveAnchor(42, undefined)).toBe(42);
+    expect(resolveAnchor(42, [])).toBe(42);
+  });
+
+  test('cited line that is a changed line is kept', () => {
+    expect(resolveAnchor(20, changed)).toBe(20);
+  });
+
+  test('cited line near a changed line snaps to the nearest', () => {
+    expect(resolveAnchor(23, changed)).toBe(21); // within window 5
+  });
+
+  test('cited line far from any changed line drops to file-level', () => {
+    expect(resolveAnchor(200, changed)).toBeUndefined();
+  });
+});
+
+describe('severity helpers', () => {
+  test('normalizeSeverity maps synonyms and unknowns', () => {
+    expect(normalizeSeverity('Critical')).toBe('critical');
+    expect(normalizeSeverity('major')).toBe('high');
+    expect(normalizeSeverity('warning')).toBe('medium');
+    expect(normalizeSeverity('nit')).toBe('info');
+    expect(normalizeSeverity('something-weird')).toBe('medium');
+    expect(normalizeSeverity(undefined)).toBe('medium');
+  });
+
+  test('severityRank orders correctly', () => {
+    expect(severityRank('critical')).toBeGreaterThan(severityRank('high'));
+    expect(severityRank('info')).toBeLessThan(severityRank('low'));
+  });
+
+  test('meetsMinSeverity filters below threshold', () => {
+    expect(meetsMinSeverity('high', 'medium')).toBe(true);
+    expect(meetsMinSeverity('medium', 'medium')).toBe(true);
+    expect(meetsMinSeverity('low', 'medium')).toBe(false);
+    expect(meetsMinSeverity('info', 'low')).toBe(false);
+  });
+});
+
+describe('fingerprintFinding', () => {
+  test('is stable across line-number shifts (line is not part of the basis)', () => {
+    const a = fingerprintFinding('src/x.ts', 'high', 'SQL injection', 'db.query(input)');
+    const b = fingerprintFinding('src/x.ts', 'high', 'SQL injection', 'db.query(input)');
+    expect(a).toBe(b);
+  });
+
+  test('normalizes whitespace/case in title and snippet', () => {
+    const a = fingerprintFinding('src/x.ts', 'high', 'SQL Injection', 'db.query(input)');
+    const b = fingerprintFinding('src/x.ts', 'high', '  sql   injection ', 'db.query(input)');
+    expect(a).toBe(b);
+  });
+
+  test('differs when file, severity, title or snippet differ', () => {
+    const base = fingerprintFinding('src/x.ts', 'high', 'Bug', 'code');
+    expect(fingerprintFinding('src/y.ts', 'high', 'Bug', 'code')).not.toBe(base);
+    expect(fingerprintFinding('src/x.ts', 'low', 'Bug', 'code')).not.toBe(base);
+    expect(fingerprintFinding('src/x.ts', 'high', 'Other', 'code')).not.toBe(base);
+    expect(fingerprintFinding('src/x.ts', 'high', 'Bug', 'other')).not.toBe(base);
+  });
+});
+
+describe('dedupeByFingerprint', () => {
+  test('removes duplicate fingerprints, keeps first', () => {
+    const findings: ResolvedFinding[] = [
+      { file: 'a', severity: 'high', title: 'x', body: '', fingerprint: 'fp1' },
+      { file: 'a', severity: 'high', title: 'x', body: '', fingerprint: 'fp1' },
+      { file: 'b', severity: 'low', title: 'y', body: '', fingerprint: 'fp2' },
+    ];
+    const out = dedupeByFingerprint(findings);
+    expect(out.length).toBe(2);
+    expect(out.map((f) => f.fingerprint)).toEqual(['fp1', 'fp2']);
+  });
+});
+
+describe('parseReviewJson', () => {
+  test('parses a bare JSON object', () => {
+    const r = parseReviewJson('{"summary":"ok","findings":[]}');
+    expect(r).not.toBeNull();
+    expect(r!.summary).toBe('ok');
+    expect(r!.findings.length).toBe(0);
+  });
+
+  test('parses JSON inside ```json fences', () => {
+    const r = parseReviewJson('```json\n{"summary":"s","findings":[{"file":"a","severity":"high","title":"t","body":"b"}]}\n```');
+    expect(r).not.toBeNull();
+    expect(r!.findings[0].file).toBe('a');
+  });
+
+  test('parses JSON surrounded by prose', () => {
+    const r = parseReviewJson('Here is my review:\n{"summary":"s","findings":[]}\nThanks!');
+    expect(r).not.toBeNull();
+    expect(r!.summary).toBe('s');
+  });
+
+  test('returns null on unparseable input', () => {
+    expect(parseReviewJson('not json at all')).toBeNull();
+    expect(parseReviewJson('')).toBeNull();
+  });
+});
+
+describe('parseConfirmedIndices', () => {
+  test('extracts the confirmed array', () => {
+    expect(parseConfirmedIndices('{"confirmed":[0,2,3]}')).toEqual([0, 2, 3]);
+  });
+
+  test('handles fenced output', () => {
+    expect(parseConfirmedIndices('```json\n{"confirmed":[1]}\n```')).toEqual([1]);
+  });
+
+  test('returns null when missing', () => {
+    expect(parseConfirmedIndices('nope')).toBeNull();
+  });
+});

--- a/tests/review-poster.test.ts
+++ b/tests/review-poster.test.ts
@@ -1,0 +1,217 @@
+import { test, expect, describe } from 'bun:test';
+import { CommentThreadStatus, CommentType, GitPullRequestCommentThread } from 'azure-devops-node-api/interfaces/GitInterfaces';
+import {
+  postReview,
+  GitApiLike,
+  SUMMARY_PROPERTY,
+  FINDING_PROPERTY,
+  FINGERPRINT_PROPERTY,
+} from '../src/review-poster';
+import { ResolvedFinding, ReviewResult } from '../src/review-orchestrator';
+
+// ---------------------------------------------------------------------------
+// Recording fake Git API. Captures every create/update so tests can assert on
+// exactly what the poster did.
+// ---------------------------------------------------------------------------
+class FakeGitApi implements GitApiLike {
+  created: GitPullRequestCommentThread[] = [];
+  updatedThreads: { thread: GitPullRequestCommentThread; threadId: number }[] = [];
+  updatedComments: { content: string; threadId: number; commentId: number }[] = [];
+  private existing: GitPullRequestCommentThread[];
+
+  constructor(existing: GitPullRequestCommentThread[] = []) {
+    this.existing = existing;
+  }
+
+  async getThreads() {
+    return this.existing;
+  }
+  async createThread(thread: GitPullRequestCommentThread) {
+    this.created.push(thread);
+    return thread;
+  }
+  async updateThread(thread: GitPullRequestCommentThread, _r: string, _p: number, threadId: number) {
+    this.updatedThreads.push({ thread, threadId });
+    return thread;
+  }
+  async updateComment(comment: { commentType: CommentType; content: string }, _r: string, _p: number, threadId: number, commentId: number) {
+    this.updatedComments.push({ content: comment.content, threadId, commentId });
+    return comment;
+  }
+
+  createdSummaries() {
+    return this.created.filter((t) => t.properties && t.properties[SUMMARY_PROPERTY]);
+  }
+  createdFindings() {
+    return this.created.filter((t) => t.properties && t.properties[FINDING_PROPERTY]);
+  }
+}
+
+function finding(over: Partial<ResolvedFinding> = {}): ResolvedFinding {
+  return {
+    file: 'src/a.ts',
+    line: 10,
+    severity: 'high',
+    title: 'Issue',
+    body: 'details',
+    fingerprint: 'fp-default',
+    ...over,
+  };
+}
+
+function result(findings: ResolvedFinding[], summary = 'overview', suppressedCount = 0): ReviewResult {
+  return { summary, findings, suppressedCount, degraded: false };
+}
+
+const REPO = 'repo';
+const PR = 42;
+
+describe('postReview — first run (no existing threads)', () => {
+  test('posts a summary thread and one thread per finding', async () => {
+    const git = new FakeGitApi([]);
+    const r = result([
+      finding({ fingerprint: 'fp1', line: 10 }),
+      finding({ fingerprint: 'fp2', line: undefined, file: 'src/b.ts', title: 'File-level' }),
+    ]);
+
+    await postReview(git, REPO, PR, true, r);
+
+    expect(git.createdSummaries().length).toBe(1);
+    expect(git.createdFindings().length).toBe(2);
+
+    // Summary content reflects counts.
+    expect(git.createdSummaries()[0].comments![0].content).toContain('2 finding(s) posted');
+  });
+
+  test('anchors line findings on the right file and leaves file-level findings unanchored', async () => {
+    const git = new FakeGitApi([]);
+    await postReview(git, REPO, PR, true, result([
+      finding({ fingerprint: 'fp1', line: 10, file: 'src/a.ts' }),
+      finding({ fingerprint: 'fp2', line: undefined, file: 'src/b.ts' }),
+    ]));
+
+    const anchored = git.createdFindings().find((t) => (t.threadContext as any)?.rightFileStart);
+    const fileLevel = git.createdFindings().find((t) => !(t.threadContext as any)?.rightFileStart);
+
+    expect((anchored!.threadContext as any).filePath).toBe('src/a.ts');
+    expect((anchored!.threadContext as any).rightFileStart.line).toBe(10);
+    expect((fileLevel!.threadContext as any).filePath).toBe('src/b.ts');
+    expect((fileLevel!.threadContext as any).rightFileStart).toBeUndefined();
+  });
+
+  test('isActive controls thread status', async () => {
+    const gitActive = new FakeGitApi([]);
+    await postReview(gitActive, REPO, PR, true, result([finding()]));
+    expect(gitActive.createdFindings()[0].status).toBe(CommentThreadStatus.Active);
+
+    const gitClosed = new FakeGitApi([]);
+    await postReview(gitClosed, REPO, PR, false, result([finding()]));
+    expect(gitClosed.createdFindings()[0].status).toBe(CommentThreadStatus.Closed);
+  });
+});
+
+describe('postReview — summary update on re-run', () => {
+  test('updates the existing summary comment in place instead of creating a new one', async () => {
+    const existingSummary: GitPullRequestCommentThread = {
+      id: 100,
+      properties: { [SUMMARY_PROPERTY]: 'true' } as any,
+      comments: [{ id: 1, commentType: CommentType.Text, content: 'old summary' }],
+    };
+    const git = new FakeGitApi([existingSummary]);
+
+    await postReview(git, REPO, PR, true, result([]));
+
+    expect(git.createdSummaries().length).toBe(0); // not recreated
+    expect(git.updatedComments.length).toBe(1);
+    expect(git.updatedComments[0].threadId).toBe(100);
+    expect(git.updatedComments[0].commentId).toBe(1);
+  });
+});
+
+describe('postReview — fingerprint dedup', () => {
+  test('skips a finding whose fingerprint already has an open thread', async () => {
+    const existing: GitPullRequestCommentThread = {
+      id: 200,
+      status: CommentThreadStatus.Active,
+      properties: { [FINDING_PROPERTY]: 'true', [FINGERPRINT_PROPERTY]: 'fp1' } as any,
+      comments: [{ id: 1, commentType: CommentType.Text, content: 'already here' }],
+    };
+    const git = new FakeGitApi([existing]);
+
+    await postReview(git, REPO, PR, true, result([finding({ fingerprint: 'fp1' })]));
+
+    expect(git.createdFindings().length).toBe(0); // not re-posted
+  });
+
+  test('re-posts a finding whose previous thread was already closed', async () => {
+    const existing: GitPullRequestCommentThread = {
+      id: 200,
+      status: CommentThreadStatus.Closed,
+      properties: { [FINDING_PROPERTY]: 'true', [FINGERPRINT_PROPERTY]: 'fp1' } as any,
+      comments: [{ id: 1, commentType: CommentType.Text, content: 'was closed' }],
+    };
+    const git = new FakeGitApi([existing]);
+
+    await postReview(git, REPO, PR, true, result([finding({ fingerprint: 'fp1' })]));
+
+    expect(git.createdFindings().length).toBe(1); // closed => treated as gone => reposted
+  });
+});
+
+describe('postReview — stale finding resolution', () => {
+  test('closes an open finding thread that no longer appears in this run', async () => {
+    const stale: GitPullRequestCommentThread = {
+      id: 300,
+      status: CommentThreadStatus.Active,
+      properties: { [FINDING_PROPERTY]: 'true', [FINGERPRINT_PROPERTY]: 'gone' } as any,
+      comments: [{ id: 1, commentType: CommentType.Text, content: 'obsolete' }],
+    };
+    const git = new FakeGitApi([stale]);
+
+    // Current run finds something else entirely.
+    await postReview(git, REPO, PR, true, result([finding({ fingerprint: 'fresh' })]));
+
+    expect(git.createdFindings().length).toBe(1); // the fresh one
+    expect(git.updatedThreads.length).toBe(1); // the stale one closed
+    expect(git.updatedThreads[0].threadId).toBe(300);
+    expect(git.updatedThreads[0].thread.status).toBe(CommentThreadStatus.Closed);
+  });
+
+  test('does not close a thread whose finding is still present', async () => {
+    const keep: GitPullRequestCommentThread = {
+      id: 300,
+      status: CommentThreadStatus.Active,
+      properties: { [FINDING_PROPERTY]: 'true', [FINGERPRINT_PROPERTY]: 'fp1' } as any,
+      comments: [{ id: 1, commentType: CommentType.Text, content: 'still valid' }],
+    };
+    const git = new FakeGitApi([keep]);
+
+    await postReview(git, REPO, PR, true, result([finding({ fingerprint: 'fp1' })]));
+
+    expect(git.updatedThreads.length).toBe(0); // not closed
+    expect(git.createdFindings().length).toBe(0); // and not duplicated
+  });
+});
+
+describe('postReview — resilience', () => {
+  test('a failing createThread does not abort the rest of the run', async () => {
+    const git = new FakeGitApi([]);
+    let first = true;
+    const orig = git.createThread.bind(git);
+    git.createThread = async (t: GitPullRequestCommentThread) => {
+      if (first) {
+        first = false;
+        throw new Error('transient ADO error');
+      }
+      return orig(t);
+    };
+
+    // Summary create throws; the two findings should still be attempted.
+    await postReview(git, REPO, PR, true, result([
+      finding({ fingerprint: 'fp1' }),
+      finding({ fingerprint: 'fp2' }),
+    ]));
+
+    expect(git.createdFindings().length).toBe(2);
+  });
+});


### PR DESCRIPTION
## What

Adds a **holistic, whole-PR review** mode (new default) where the AI sees the entire pull request at once and posts a summary thread plus line-anchored findings with severity. The legacy per-file behaviour is fully preserved behind `reviewMode: perFile`, so existing pipelines don't change unless they opt in.

## Highlights

- **`ai-services`** — refreshed model defaults to the current balanced tier (`claude-sonnet-4-6`, `gpt-5.4`, `gemini-3-pro`, `qwen3`); stop sending `temperature` on models that now reject it (Anthropic Opus 4.7/4.8/Fable, OpenAI GPT-5/o-series); optional native JSON mode. Providers stay thin text→text.
- **`pr-utils`** — diffs annotated with real new-file line numbers + a `changedLines` anchor set; best-effort fetch of PR title/description, linked work items, and existing human comments.
- **`review-orchestrator`** (new) — structured-JSON contract, char/4 input budget with batch-on-overflow + synthesis, parse→retry→degrade, verification critic pass, line-independent fingerprint dedup, anchor validate/snap/drop, `minSeverity` filter.
- **`review-poster`** (new) — summary updated in place across runs, fingerprint dedup vs existing threads, stale-finding closure; every Git call independently guarded.
- **`index`** — `reviewMode` routing, new inputs, `SucceededWithIssues` on malfunction (the reviewer never blocks the pipeline).
- **`task.json`** — 7 new inputs kept in sync with `index`; output default `1000 → 8000`.

## Build & CI

- **`copy-modules`** — exclude `react`/`react-dom`/`scheduler`/`typescript` (unused at runtime); `dist/node_modules` shrinks ~63M → ~39M. Bundle verified to resolve in isolation (no parent `node_modules`).
- **Tests** — `bun:test` unit + functional suites (**47 tests**) driving the orchestrator and poster through mocked AI and Git APIs.
- **CI** — new `ci.yml` runs typecheck + tests on every push/PR. The deploy workflow gains a `test` job that `publish` `needs:`, so failing tests block the marketplace deploy.

## Compatibility

No breaking changes: the non-AI markdown/comment path is untouched, and AI users can revert to the old behaviour with `reviewMode: perFile`. The task `id`/`name` are unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `bun test` — 47 passing
- [x] `npm run build` succeeds; `dist` audited (required deps in, unused out, resolves standalone)
- [ ] Manual smoke test against a real PR before tagging a release